### PR TITLE
ODP-2743 : Fix nifi build by excluding banned dependencies in nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hwx-schema-registry-bundle/nifi-hwx-schema-registry-service/pom.xml
@@ -67,7 +67,7 @@ limitations under the License.
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>
- 
+
         <!-- Schema Registry Client-->
         <dependency>
             <groupId>com.hortonworks.registries</groupId>
@@ -77,6 +77,14 @@ limitations under the License.
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -109,7 +117,7 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
This patch was tested locally.