### PR TITLE
ODP-2718|ODP-2771 Refactor shebangs for python scripts to ambari-python-wrap

### DIFF
--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/mocknifi-secure/server.py
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/mocknifi-secure/server.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 import logging
 

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/mocknifi-unsecure/server.py
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/resources/mocknifi-unsecure/server.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 import logging
 

--- a/minifi/minifi-integration-tests/src/test/resources/tailFileServer.py
+++ b/minifi/minifi-integration-tests/src/test/resources/tailFileServer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env ambari-python-wrap
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/src/main/resources/scripts/ranger_credential_helper.py
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-resources/src/main/resources/scripts/ranger_credential_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env ambari-python-wrap
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/__init__.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/__init__.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/compress.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/compress.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/decompress.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/decompress.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/read_first_line.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/callbacks/read_first_line.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_external_module.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_external_module.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_invalid.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_invalid.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_log_vm_stats.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_log_vm_stats.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_modules_path.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_modules_path.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_reader.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_reader.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_update_attribute.py
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/jython/test_update_attribute.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
ODP-2718|ODP-2771 Refactor shebangs for python scripts to ambari-python-wrap

Tested in RHEL9, RHEL8, UBUNTU22