### PR TITLE
ODP-4729 NoClassDefFoundError Jackson-core

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -21,7 +21,6 @@
         <artifactId>nifi</artifactId>
         <version>1.28.1.3.3.6.2-1</version>
     </parent>
-    <groupId>org.apache.nifi.registry</groupId>
     <artifactId>nifi-registry</artifactId>
     <packaging>pom</packaging>
     <description>Provides a central location for storage and management of shared resources across one or more instances
@@ -105,6 +104,12 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-alpn-server</artifactId>
                 <version>${jetty.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.bom.version}</version>
                 <scope>compile</scope>
             </dependency>
         <!-- lib/java11 -->


### PR DESCRIPTION
Nifi-Registry bootstrap fails with NoClassDefFoundError
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.JsonProcessingException

Jackson-core has been added as a dependency in nifi-registry pom.xml

Tested locally.