### PR TITLE
ODP-4729 CNF missing Jackson dependency in NIFI-Registry

### DIFF
--- a/nifi-registry/nifi-registry-assembly/pom.xml
+++ b/nifi-registry/nifi-registry-assembly/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.bom.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-utils</artifactId>
         </dependency>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -107,12 +107,6 @@
                 <version>${jetty.version}</version>
                 <scope>compile</scope>
             </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.bom.version}</version>
-                <scope>compile</scope>
-            </dependency>
         <!-- lib/java11 -->
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
https://accelcentral.atlassian.net/browse/ODP-4729
ERROR [NiFi logging handler] org.apache.nifi.registry.StdErr Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.JsonProcessingException

Patch tested locally as well with. new RPMS on the cluster.