### PR TITLE
Fix nifi registry authorizer instantiation error

### DIFF
--- a/RANGER_AUTHORIZATION_FIX.md
+++ b/RANGER_AUTHORIZATION_FIX.md
@@ -1,0 +1,133 @@
+# NiFi Registry Ranger Authorization Fix
+
+## Problem Description
+
+The error you encountered:
+
+```
+Caused by: java.lang.IllegalStateException: Extension not found in any of the configured class loaders: org.apache.nifi.ranger.authorization.ManagedRangerAuthorizer
+```
+
+This error occurs because:
+
+1. **Wrong Authorizer Class**: The configuration is trying to use `org.apache.nifi.ranger.authorization.ManagedRangerAuthorizer`, which is from the main NiFi bundle, not NiFi Registry.
+
+2. **Missing Extension**: NiFi Registry has its own separate Ranger extension that provides `org.apache.nifi.registry.ranger.RangerAuthorizer`.
+
+3. **Extension Not Installed**: The NiFi Registry Ranger extension is not installed or not properly configured.
+
+## Solution
+
+### Option 1: Use the Default Authorizer (Quick Fix)
+
+If you don't need Ranger integration, simply use the default `managed-authorizer` that's already configured in `authorizers.xml`:
+
+1. In `nifi-registry.properties`, ensure:
+   ```properties
+   nifi.registry.security.authorizer=managed-authorizer
+   ```
+
+2. The `managed-authorizer` is already configured in `authorizers.xml` and uses file-based authorization.
+
+### Option 2: Install and Configure Ranger Extension (Complete Solution)
+
+To properly use Ranger with NiFi Registry:
+
+#### Step 1: Install the Ranger Extension
+
+**Option A: Build with Ranger Profile**
+```bash
+cd nifi-registry
+mvn clean install -Pinclude-ranger
+```
+This will install the extension at `${NIFI_REG_HOME}/ext/ranger`.
+
+**Option B: Build Extension Separately**
+```bash
+cd nifi-registry
+mvn clean install -f nifi-registry-extensions/nifi-registry-ranger
+```
+Then unzip the created extension:
+```bash
+mkdir -p ${NIFI_REG_HOME}/ext/ranger
+unzip -d ${NIFI_REG_HOME}/ext/ranger nifi-registry-extensions/nifi-registry-ranger-assembly/target/nifi-registry-ranger-*-bin.zip
+```
+
+#### Step 2: Configure NiFi Registry Properties
+
+In `nifi-registry.properties`, add:
+```properties
+# Specify Ranger extension directory
+nifi.registry.extension.dir.ranger=./ext/ranger/lib
+
+# Specify Ranger authorizer identifier
+nifi.registry.security.authorizer=ranger-authorizer
+```
+
+#### Step 3: Configure Authorizers
+
+In `authorizers.xml`, uncomment and configure the ranger-authorizer:
+
+```xml
+<authorizer>
+    <identifier>ranger-authorizer</identifier>
+    <class>org.apache.nifi.registry.ranger.RangerAuthorizer</class>
+    <property name="Ranger Service Type">nifi-registry</property>
+    <property name="User Group Provider">file-user-group-provider</property>
+    <property name="Ranger Application Id">nifi-registry-service-name</property>
+    <property name="Ranger Security Config Path">./ext/ranger/conf/ranger-nifi-registry-security.xml</property>
+    <property name="Ranger Audit Config Path">./ext/ranger/conf/ranger-nifi-registry-audit.xml</property>
+    <property name="Ranger Admin Identity">ranger@NIFI</property>
+    <property name="Ranger Kerberos Enabled">false</property>
+</authorizer>
+```
+
+#### Step 4: Configure Ranger Server
+
+At the Ranger server side:
+
+1. Create a NiFi Registry service with these properties:
+   - **NiFi Registry URL**: `https://your-nifi-registry:18443/nifi-registry-api/policies/resources`
+   - **Authentication Type**: SSL
+   - **Keystore**: Path to keystore for client certificate
+   - **Keystore Type**: JKS (or appropriate type)
+   - **Keystore Password**: Your keystore password
+   - **Truststore**: Path to truststore for server verification
+   - **Truststore Type**: JKS (or appropriate type)
+   - **Truststore Password**: Your truststore password
+
+2. If using Kerberos, add configuration:
+   - **policy.download.auth.users**: NiFi Registry service principal
+
+## Key Differences Between NiFi and NiFi Registry Ranger Integration
+
+| Component | NiFi | NiFi Registry |
+|-----------|------|---------------|
+| Authorizer Class | `org.apache.nifi.ranger.authorization.ManagedRangerAuthorizer` | `org.apache.nifi.registry.ranger.RangerAuthorizer` |
+| Bundle Location | `nifi-nar-bundles/nifi-ranger-bundle` | `nifi-registry-extensions/nifi-registry-ranger` |
+| Service Type | `nifi` | `nifi-registry` |
+| Extension Directory | `./lib` | `./ext/ranger/lib` |
+
+## Verification
+
+After applying the fix:
+
+1. **Check Extension Loading**: Look for log messages indicating the Ranger extension was loaded successfully.
+
+2. **Test Authorization**: Try accessing NiFi Registry with different users to verify Ranger policies are being enforced.
+
+3. **Check Ranger Audit**: Verify that access attempts are being logged in Ranger's audit system.
+
+## Troubleshooting
+
+- **Class Not Found**: Ensure the Ranger extension is properly installed in the `ext/ranger/lib` directory.
+- **Connection Issues**: Verify network connectivity between NiFi Registry and Ranger server.
+- **Certificate Issues**: Ensure SSL certificates are properly configured for mutual authentication.
+- **Kerberos Issues**: If using Kerberos, verify principal and keytab configurations.
+
+## Files Modified
+
+1. `authorizers.xml` - Added proper Ranger authorizer configuration with documentation
+2. Created this documentation file explaining the issue and solution
+
+The root cause was attempting to use the main NiFi's Ranger authorizer class instead of the NiFi Registry-specific one, combined with the Ranger extension not being installed.

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/authorizers.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/authorizers.xml
@@ -320,4 +320,35 @@
         <property name="Access Policy Provider">file-access-policy-provider</property>
     </authorizer>
 
+    <!--
+        The RangerAuthorizer provides Apache Ranger integration for NiFi Registry authorization.
+        This authorizer requires the NiFi Registry Ranger extension to be installed.
+        
+        To install the extension:
+        1. Build NiFi Registry with the include-ranger profile: mvn clean install -Pinclude-ranger
+        2. Or build the extension separately and install it manually (see README in nifi-registry-extensions/nifi-registry-ranger)
+        
+        Configuration properties:
+        - User Group Provider - The identifier for a User Group Provider defined above
+        - Ranger Service Type - The service type for Ranger (default: nifi-registry)
+        - Ranger Application Id - The service name configured in Ranger
+        - Ranger Security Config Path - Path to ranger security configuration
+        - Ranger Audit Config Path - Path to ranger audit configuration
+        - Ranger Admin Identity - Identity used by Ranger to access NiFi Registry
+        - Ranger Kerberos Enabled - Whether Ranger is kerberized (default: false)
+    -->
+    <!-- To enable the ranger-authorizer remove 2 lines. This is 1 of 2.
+    <authorizer>
+        <identifier>ranger-authorizer</identifier>
+        <class>org.apache.nifi.registry.ranger.RangerAuthorizer</class>
+        <property name="Ranger Service Type">nifi-registry</property>
+        <property name="User Group Provider">file-user-group-provider</property>
+        <property name="Ranger Application Id">nifi-registry-service-name</property>
+        <property name="Ranger Security Config Path">./ext/ranger/conf/ranger-nifi-registry-security.xml</property>
+        <property name="Ranger Audit Config Path">./ext/ranger/conf/ranger-nifi-registry-audit.xml</property>
+        <property name="Ranger Admin Identity">ranger@NIFI</property>
+        <property name="Ranger Kerberos Enabled">false</property>
+    </authorizer>
+    To enable the ranger-authorizer remove 2 lines. This is 2 of 2. -->
+
 </authorizers>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000) - Fix NiFi Registry Ranger Authorizer `Extension not found` error

This PR addresses an `IllegalStateException` where NiFi Registry failed to instantiate the Authorizer, specifically when attempting to load `org.apache.nifi.ranger.authorization.ManagedRangerAuthorizer`. The root cause was the incorrect use of the main NiFi Ranger authorizer class instead of the NiFi Registry-specific Ranger authorizer (`org.apache.nifi.registry.ranger.RangerAuthorizer`), coupled with the Ranger extension not being properly installed or configured for NiFi Registry.

This fix provides comprehensive guidance by:
*   Updating `authorizers.xml` with a commented-out, correctly configured `ranger-authorizer` entry, including detailed instructions on its properties and prerequisites.
*   Adding a new documentation file (`RANGER_AUTHORIZATION_FIX.md`) that explains the problem, provides two solution options (using the default authorizer or proper Ranger integration), outlines detailed installation and configuration steps for the NiFi Registry Ranger extension, highlights key differences between NiFi and NiFi Registry Ranger integration, and offers troubleshooting tips.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files

---
<a href="https://cursor.com/background-agent?bcId=bc-e955bb8a-0c17-4153-bcd2-565b7c1332c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e955bb8a-0c17-4153-bcd2-565b7c1332c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

