### PR TITLE
NIFI-8843: ZooKeeper leader election for NiFi Registry HA

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/pom.xml
@@ -23,11 +23,6 @@
     <artifactId>nifi-framework-zookeeper-bundle</artifactId>
     <packaging>pom</packaging>
 
-    <properties>
-        <zookeeper.version>3.9.4</zookeeper.version>
-        <curator.version>5.9.0</curator.version>
-    </properties>
-
     <modules>
         <module>nifi-framework-cluster-zookeeper</module>
         <module>nifi-framework-zookeeper-leader-election</module>

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -1217,6 +1217,112 @@ providing 2 total locations, including `nifi.registry.extension.dir.1`.
 |`nifi.registry.kerberos.spengo.authentication.expiration`|The expiration duration of a successful Kerberos user authentication, if used. The default value is `12 hours`.
 |====
 
+[[maintenance_mode]]
+=== Maintenance Mode
+
+NiFi Registry exposes a runtime maintenance mode toggle via the Spring Boot Actuator endpoint `/nifi-registry/actuator/maintenance`.
+When enabled, all mutating HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`) to the NiFi Registry API are rejected immediately with
+`503 Service Unavailable` and a `Retry-After: 60` header.  Read operations (`GET`, `HEAD`) continue to be served normally.
+
+Maintenance mode is *not* persisted.  It resets to disabled whenever the process restarts.
+
+.Enabling maintenance mode
+----
+curl -X POST https://localhost:18443/nifi-registry/actuator/maintenance \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": true}'
+----
+
+.Checking maintenance mode state
+----
+curl https://localhost:18443/nifi-registry/actuator/maintenance
+# → {"enabled":true}
+
+curl https://localhost:18443/nifi-registry/actuator/health
+# → includes "maintenanceMode": true in the health detail
+----
+
+.Re-enabling writes after backup
+----
+curl -X POST https://localhost:18443/nifi-registry/actuator/maintenance \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": false}'
+----
+
+NOTE: The `/actuator` endpoints are secured by the same authorization policy as the rest of the Registry API.
+Only principals with `READ` or `WRITE` access to the `Actuator` resource are permitted to call them.
+
+[[cluster_properties]]
+=== Cluster Properties
+
+These properties control active-active clustering.  When clustering is enabled, multiple Registry nodes share a single
+external database and use the `CACHE_VERSION` table to keep their in-memory authorization caches coherent.
+
+IMPORTANT: Active-active clustering requires an external database (PostgreSQL or MySQL).  The embedded H2 database is
+not suitable for multi-node deployments because it does not support concurrent access from separate JVM processes.
+All nodes must also be configured to use the database-backed flow persistence provider and the database-backed
+user/group and access-policy authorizers (see `providers.xml` and `authorizers.xml`).
+
+|====
+|*Property*|*Description*
+|`nifi.registry.cluster.enabled`|Set to `true` to activate cluster mode.  When `false` (the default) the
+`CacheRefreshPoller` background thread does not start and no cluster-related database tables are read.
+|`nifi.registry.cluster.node.identifier`|Optional human-readable label for this node. Used in cluster leader-election
+records (stored in the `CLUSTER_LEADER` table) and included in log messages to make it easier to identify which node
+generated a log entry. When blank, the JVM hostname is used.
+|`nifi.registry.cluster.cache.refresh.interval.ms`|Interval, in milliseconds, at which each node polls the
+`CACHE_VERSION` table in the shared database to check whether another node has mutated authorization data.
+When a version increment is detected the node reloads the affected in-memory cache from the database.
+The default value is `15000` (15 seconds).  Reduce this value to shorten the maximum staleness window at the
+cost of more frequent database reads.
+|====
+
+.Minimum required configuration for a two-node cluster
+----
+# nifi-registry.properties on every node
+nifi.registry.cluster.enabled=true
+nifi.registry.cluster.node.identifier=node-1   # change per node
+nifi.registry.cluster.cache.refresh.interval.ms=15000
+
+# shared external database (same on all nodes)
+nifi.registry.db.url=jdbc:postgresql://pg-host:5432/nifi_registry
+nifi.registry.db.driver.class=org.postgresql.Driver
+nifi.registry.db.username=nifireg
+nifi.registry.db.password=<password>
+----
+
+NOTE: Place the PostgreSQL or MySQL JDBC driver JAR in the `lib` directory on every Registry node, or set
+`nifi.registry.db.driver.directory` to the directory containing the driver.
+
+[[leader_election]]
+=== Leader Election
+
+When cluster mode is enabled, exactly one node at a time is designated the *leader* via a TTL-based lease
+stored in the `CLUSTER_LEADER` database table.  Leadership is used to coordinate tasks that must run on
+exactly one node — most notably, delivering <<Event Hooks,event hook>> notifications from the durable
+`REGISTRY_EVENT` log.
+
+[options="header,footer"]
+|====
+|*Parameter*|*Value*|*Description*
+|Lease duration|30 seconds|How long a node's leader status is valid before it must be renewed.
+|Heartbeat interval|10 seconds|How often each node attempts to renew (if leader) or claim (if follower) the lease.
+|====
+
+The election algorithm runs on every heartbeat:
+
+. *Renew* — if this node already owns the `CLUSTER_LEADER` row, update `EXPIRES_AT` and stay leader.
+. *Claim* — if the lease has expired (previous leader died), take ownership and become leader.
+. *Bootstrap* — if no row exists yet (first node to start), insert the row and become leader.
+. *Follow* — if another node holds a valid lease, remain a follower this cycle.
+
+If the current leader node stops sending heartbeats, any follower node will claim the lease within one
+lease-duration window (30 seconds by default) and resume leader duties automatically.  There is no manual
+failover step required.
+
+NOTE: Leader election and event-hook delivery require cluster mode (`nifi.registry.cluster.enabled=true`).
+In standalone mode these features are inactive and event hooks are delivered in-process as before.
+
 == Metadata Database
 
 The metadata database maintains the knowledge of which buckets exist, which versioned items belong to which buckets, as well as the version history for each item.
@@ -1606,6 +1712,23 @@ Qualified class name: `org.apache.nifi.registry.aws.S3BundlePersistenceProvider`
 == Event Hooks
 Event hooks are an integration point that allows for custom code to to be triggered when NiFi Registry application events occur.
 
+[[cluster_event_hooks]]
+=== Event Hook Delivery in Cluster Mode
+
+In standalone mode (the default), events are queued in memory on the node that received the request and
+delivered to hook providers on that same node.
+
+When `nifi.registry.cluster.enabled=true`, event delivery changes to a durable, exactly-once model:
+
+* *Any* node that handles a write request persists the event to the `REGISTRY_EVENT` database table.
+* Only the current <<leader_election,leader>> node polls for unprocessed events (every 5 seconds) and
+  delivers them to the configured hook providers.
+* Once delivered, each row is marked `PROCESSED = TRUE`.  Processed rows older than 7 days are
+  automatically purged by the leader.
+
+This guarantees that every event fires exactly once even if the node that handled the original request
+crashes before delivery completes, or if cluster membership changes mid-operation.
+
 [options="header,footer"]
 |==================================================================================================================================================
 | Event Name | Description
@@ -1736,9 +1859,33 @@ In order to prevent data loss it is important to consider backup and recovery op
  - Persistence providers
  - Configuration files
 
+=== Online Backup with Maintenance Mode
+
+Stopping NiFi Registry to take a consistent backup is disruptive to connected NiFi instances.
+The <<maintenance_mode,Maintenance Mode>> actuator endpoint provides a zero-downtime alternative:
+
+1. Enable maintenance mode — all write requests are rejected with `503 Service Unavailable` while reads continue uninterrupted.
+2. Take a consistent snapshot of the database and flow storage.
+3. Disable maintenance mode — writes resume immediately.
+
+----
+# 1. Enable maintenance mode
+curl -X POST https://localhost:18443/nifi-registry/actuator/maintenance \
+  -H "Content-Type: application/json" -d '{"enabled": true}'
+
+# 2. Copy the H2 database files / pg_dump / rsync flow storage …
+
+# 3. Re-enable writes
+curl -X POST https://localhost:18443/nifi-registry/actuator/maintenance \
+  -H "Content-Type: application/json" -d '{"enabled": false}'
+----
+
+NOTE: In an active-active cluster, enable maintenance mode on each node before taking the backup.
+Each node's maintenance mode state is independent and must be toggled separately.
+
 === Metadata Database
 
-If using H2, the database file should be backed up periodically to an external location. In order to ensure a proper backup, NiFi Registry should be stopped to ensure no write operations are occurring while copying the file.
+If using H2, the database file should be backed up periodically to an external location. In order to ensure a proper backup, NiFi Registry should be stopped to ensure no write operations are occurring while copying the file, or <<maintenance_mode,Maintenance Mode>> can be used to drain writes without stopping the process.
 
 If using Postgres, backups may be taken on the Postgres database, or Postgres may be configured for high availability such that there is a failover or backup instance.
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -366,6 +366,43 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
         </dependency>
+        <!-- ZooKeeper / Curator (used for ZkLeaderElectionManager) -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.apache.nifi.registry</groupId>
@@ -396,6 +433,12 @@
                     <artifactId>spring-jdbc</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.unboundid</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/DatabaseLeaderElectionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/DatabaseLeaderElectionManager.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.net.InetAddress;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.sql.DataSource;
+
+/**
+ * Database-backed implementation of {@link LeaderElectionManager}.
+ *
+ * <p>Uses a single row in the {@code CLUSTER_LEADER} table as a TTL-based
+ * distributed lock. Each cluster node tries every {@value #HEARTBEAT_INTERVAL_SECONDS}
+ * seconds to either renew its own lease or claim an expired one. A node is
+ * considered the leader when it holds a lease whose {@code EXPIRES_AT} is in
+ * the future.
+ *
+ * <p>Lease duration: {@value #LEASE_DURATION_SECONDS} seconds.
+ * Heartbeat interval: {@value #HEARTBEAT_INTERVAL_SECONDS} seconds.
+ *
+ * <p>This bean is always created by Spring but only activates the background
+ * heartbeat thread when {@code nifi.registry.cluster.enabled=true}. In
+ * standalone mode {@link #isLeader()} always returns {@code false}.
+ */
+public class DatabaseLeaderElectionManager implements LeaderElectionManager, DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseLeaderElectionManager.class);
+
+    static final int LEASE_DURATION_SECONDS = 30;
+    static final int HEARTBEAT_INTERVAL_SECONDS = 10;
+    private static final String LOCK_KEY = "LEADER";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final NiFiRegistryProperties properties;
+    private final String nodeId;
+    private final AtomicBoolean currentLeader = new AtomicBoolean(false);
+
+    private ScheduledExecutorService scheduler;
+
+    public DatabaseLeaderElectionManager(final DataSource dataSource,
+            final NiFiRegistryProperties properties) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.properties = properties;
+        this.nodeId = resolveNodeId(properties);
+    }
+
+    public void start() {
+        if (!properties.isClusterEnabled()) {
+            LOGGER.info("Cluster mode is disabled; DatabaseLeaderElectionManager will not start.");
+            return;
+        }
+
+        LOGGER.info("Starting DatabaseLeaderElectionManager for node '{}' with lease {}s / heartbeat {}s.",
+                nodeId, LEASE_DURATION_SECONDS, HEARTBEAT_INTERVAL_SECONDS);
+
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread t = new Thread(r, "LeaderElectionHeartbeat");
+            t.setDaemon(true);
+            return t;
+        });
+
+        // Run first heartbeat immediately, then every HEARTBEAT_INTERVAL_SECONDS.
+        scheduler.scheduleWithFixedDelay(
+                this::heartbeat,
+                0, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void destroy() {
+        if (scheduler != null) {
+            LOGGER.info("Shutting down DatabaseLeaderElectionManager.");
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Override
+    public boolean isLeader() {
+        return currentLeader.get();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal heartbeat
+    // -------------------------------------------------------------------------
+
+    private void heartbeat() {
+        try {
+            final boolean leader = tryAcquireOrRenew();
+            final boolean wasLeader = currentLeader.getAndSet(leader);
+            if (leader && !wasLeader) {
+                LOGGER.info("Node '{}' became the cluster leader.", nodeId);
+            } else if (!leader && wasLeader) {
+                LOGGER.warn("Node '{}' lost the cluster leader lease.", nodeId);
+            }
+        } catch (final Exception e) {
+            LOGGER.error("Unexpected error during leader heartbeat", e);
+            currentLeader.set(false);
+        }
+    }
+
+    /**
+     * Tries to acquire or renew the leader lease.
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>Try to renew our own lease (UPDATE ... WHERE NODE_ID = self).</li>
+     *   <li>If that fails, try to claim an expired lease (UPDATE ... WHERE EXPIRES_AT &lt; now).</li>
+     *   <li>If that fails, try to INSERT the first-ever row.</li>
+     *   <li>Otherwise remain a follower.</li>
+     * </ol>
+     */
+    boolean tryAcquireOrRenew() {
+        final Timestamp expires = Timestamp.from(Instant.now().plusSeconds(LEASE_DURATION_SECONDS));
+        final Timestamp now = Timestamp.from(Instant.now());
+
+        // 1. Renew existing lease if we're already the leader.
+        final int renewed = jdbcTemplate.update(
+                "UPDATE CLUSTER_LEADER SET EXPIRES_AT = ? WHERE LOCK_KEY = ? AND NODE_ID = ?",
+                expires, LOCK_KEY, nodeId);
+        if (renewed > 0) {
+            return true;
+        }
+
+        // 2. Claim the lease if it has expired (another node died or first run).
+        final int claimed = jdbcTemplate.update(
+                "UPDATE CLUSTER_LEADER SET NODE_ID = ?, EXPIRES_AT = ? WHERE LOCK_KEY = ? AND EXPIRES_AT < ?",
+                nodeId, expires, LOCK_KEY, now);
+        if (claimed > 0) {
+            return true;
+        }
+
+        // 3. No row exists yet — first node to start. INSERT to create it.
+        try {
+            jdbcTemplate.update(
+                    "INSERT INTO CLUSTER_LEADER (LOCK_KEY, NODE_ID, EXPIRES_AT) VALUES (?, ?, ?)",
+                    LOCK_KEY, nodeId, expires);
+            return true;
+        } catch (final Exception e) {
+            // Another node raced and inserted first, or the active leader holds the lease.
+            LOGGER.debug("No row exists yet — first node to start. INSERT to create it. Could not acquire leader lease for node '{}': {}", nodeId, e.getMessage());
+            return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static String resolveNodeId(final NiFiRegistryProperties props) {
+        final String configured = props.getClusterNodeIdentifier();
+        if (!StringUtils.isBlank(configured)) {
+            return configured;
+        }
+
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to resolve hostname for node identifier; using 'unknown'", e);
+            return "unknown";
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/HttpReplicationClient.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/HttpReplicationClient.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link ReplicationClient} backed by the JDK {@link HttpClient} (JDK 11+).
+ *
+ * <p>No additional Maven dependency is required. A single shared
+ * {@link HttpClient} instance is used for all requests; it is thread-safe
+ * and manages its own connection pool.
+ *
+ * <p>Fan-out to followers is performed on a cached-thread-pool executor so
+ * it does not block the leader's response to the original client. Failures
+ * are logged; the implementation does not retry (a future phase can add
+ * retry/reconciliation logic).
+ *
+ * <p>Hop-by-hop headers (RFC 7230 §6.1) are stripped before forwarding to
+ * avoid protocol errors on independent TCP connections.
+ */
+public class HttpReplicationClient implements ReplicationClient, DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpReplicationClient.class);
+
+    /** Header added to fan-out requests so followers skip re-forwarding. */
+    public static final String REPLICATION_HEADER = "X-Registry-Replication";
+    /** Shared-secret header verifying that a replicated request comes from the leader. */
+    public static final String INTERNAL_AUTH_HEADER = "X-Registry-Internal-Auth";
+
+    private static final Set<String> HOP_BY_HOP = Set.of(
+            "connection", "keep-alive", "transfer-encoding", "te",
+            "trailers", "upgrade", "proxy-authorization", "proxy-authenticate",
+            "content-length"   // HttpClient sets this from the body publisher
+    );
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+    private final String authToken;
+    private final HttpClient httpClient;
+    private final ExecutorService fanOutExecutor;
+
+    public HttpReplicationClient(final String authToken) {
+        this.authToken = authToken;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .executor(Executors.newCachedThreadPool(r -> {
+                    final Thread t = new Thread(r, "registry-replication-http");
+                    t.setDaemon(true);
+                    return t;
+                }))
+                .build();
+        this.fanOutExecutor = Executors.newCachedThreadPool(r -> {
+            final Thread t = new Thread(r, "registry-fanout");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @Override
+    public void destroy() {
+        fanOutExecutor.shutdown();
+        try {
+            if (!fanOutExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                fanOutExecutor.shutdownNow();
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ReplicationClient
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void replicateToFollowers(final String path, final String method,
+            final Map<String, String> headers, final byte[] body,
+            final List<NodeAddress> followers) {
+
+        for (final NodeAddress follower : followers) {
+            fanOutExecutor.submit(() -> replicateToOne(path, method, headers, body, follower));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private void replicateToOne(final String path, final String method,
+            final Map<String, String> headers, final byte[] body, final NodeAddress follower) {
+        final String url = buildUrl(follower.getBaseUrl(), path, null);
+        LOGGER.debug("Replicating {} {} to follower '{}'.", method, path, follower.getNodeId());
+
+        try {
+            final HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .method(method, bodyPublisher(body))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header(REPLICATION_HEADER, "true")
+                    .header(INTERNAL_AUTH_HEADER, authToken);
+
+            headers.forEach((name, value) -> {
+                if (!HOP_BY_HOP.contains(name.toLowerCase())
+                        && !REPLICATION_HEADER.equalsIgnoreCase(name)
+                        && !INTERNAL_AUTH_HEADER.equalsIgnoreCase(name)) {
+                    try {
+                        builder.header(name, value);
+                    } catch (final IllegalArgumentException e) {
+                        // Skip restricted headers (e.g. host).
+                    }
+                }
+            });
+
+            final HttpResponse<Void> response =
+                    httpClient.send(builder.build(), HttpResponse.BodyHandlers.discarding());
+
+            if (response.statusCode() >= 400) {
+                LOGGER.warn("Replication to follower '{}' for {} {} returned HTTP {}.",
+                        follower.getNodeId(), method, path, response.statusCode());
+            } else {
+                LOGGER.debug("Replicated {} {} to follower '{}': HTTP {}.",
+                        method, path, follower.getNodeId(), response.statusCode());
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Interrupted replicating {} {} to follower '{}'.", method, path, follower.getNodeId());
+        } catch (final Exception e) {
+            LOGGER.error("Failed to replicate {} {} to follower '{}': {}",
+                    method, path, follower.getNodeId(), e.getMessage());
+        }
+    }
+
+    private static String buildUrl(final String baseUrl, final String path, final String queryString) {
+        final StringBuilder sb = new StringBuilder(baseUrl);
+        if (!path.startsWith("/")) {
+            sb.append('/');
+        }
+        sb.append(path);
+        if (queryString != null && !queryString.isEmpty()) {
+            sb.append('?').append(queryString);
+        }
+        return sb.toString();
+    }
+
+    private static HttpRequest.BodyPublisher bodyPublisher(final byte[] body) {
+        return (body != null && body.length > 0)
+                ? HttpRequest.BodyPublishers.ofByteArray(body)
+                : HttpRequest.BodyPublishers.noBody();
+    }
+
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/LeaderChangeListener.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/LeaderChangeListener.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+/**
+ * Callback interface for components that need to react to leader election
+ * state changes (e.g. immediately draining a pending-event queue when this
+ * node becomes the leader).
+ */
+public interface LeaderChangeListener {
+
+    /** Called on the election thread immediately after this node acquires leadership. */
+    void onStartLeading();
+
+    /** Called on the election thread immediately after this node loses leadership. */
+    void onStopLeading();
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/LeaderElectionConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/LeaderElectionConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
+
+/**
+ * Selects the active {@link LeaderElectionManager} implementation.
+ *
+ * <ul>
+ *   <li>{@code nifi.registry.cluster.coordination=database} (default) —
+ *       creates {@link DatabaseLeaderElectionManager}</li>
+ *   <li>{@code nifi.registry.cluster.coordination=zookeeper} —
+ *       creates {@link ZkLeaderElectionManager} using the
+ *       {@link CuratorFramework} bean produced by {@link ZkClientFactory}</li>
+ * </ul>
+ *
+ * <p>This configuration class owns the lifecycle of both implementations.
+ * {@code DatabaseLeaderElectionManager} and {@code ZkLeaderElectionManager}
+ * are no longer annotated with {@code @Component} — they are only instantiated
+ * here, preventing accidental double-registration.
+ */
+@Configuration
+@Import(ZkClientFactory.class)
+public class LeaderElectionConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeaderElectionConfiguration.class);
+
+    @Bean
+    public LeaderElectionManager leaderElectionManager(
+            final NiFiRegistryProperties properties,
+            final DataSource dataSource,
+            // Optional — only resolved when coordination=zookeeper
+            final org.springframework.beans.factory.ObjectProvider<CuratorFramework> curatorProvider) {
+
+        if (properties.isClusterEnabled() && properties.isZooKeeperCoordination()) {
+            LOGGER.info("Cluster coordination=zookeeper; creating ZkLeaderElectionManager.");
+            final CuratorFramework curator = curatorProvider.getObject();
+            final ZkLeaderElectionManager manager = new ZkLeaderElectionManager(curator, properties);
+            manager.start();
+            return manager;
+        }
+
+        LOGGER.info("Cluster coordination=database; creating DatabaseLeaderElectionManager.");
+        final DatabaseLeaderElectionManager manager = new DatabaseLeaderElectionManager(dataSource, properties);
+        manager.start();
+        return manager;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/LeaderElectionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/LeaderElectionManager.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+/**
+ * Provides leader-election semantics for NiFi Registry cluster nodes.
+ *
+ * <p>In a single-node deployment the implementation always returns {@code false}
+ * from {@link #isLeader()} (the node is not participating in election). When
+ * {@code nifi.registry.cluster.enabled=true} the active implementation performs
+ * distributed leader election so that exactly one node is leader at any point
+ * in time.
+ *
+ * <p>Two implementations are available, selected by
+ * {@code nifi.registry.cluster.coordination}:
+ * <ul>
+ *   <li>{@code database} (default) — TTL-based lease in the {@code CLUSTER_LEADER} table</li>
+ *   <li>{@code zookeeper} — Apache Curator {@code LeaderSelector} backed by ZooKeeper</li>
+ * </ul>
+ */
+public interface LeaderElectionManager {
+
+    /**
+     * Returns {@code true} if this node currently holds the leader role.
+     *
+     * <p>For the database implementation the value lags by up to the heartbeat
+     * interval (10 s). For the ZooKeeper implementation it is verified against
+     * ZooKeeper at most every 5 seconds.
+     */
+    boolean isLeader();
+
+    /**
+     * Registers a listener that will be notified whenever this node gains or
+     * loses the leader role. Listeners are notified on the election thread;
+     * implementations must not block indefinitely.
+     *
+     * <p>Default implementation is a no-op so existing implementations are
+     * not required to override it immediately.
+     */
+    default void addLeaderChangeListener(final LeaderChangeListener listener) {
+    }
+
+    /**
+     * Returns the node identifier of the current cluster leader, or empty if
+     * the leader is unknown (e.g. during election or ZK session loss).
+     *
+     * <p>Default returns empty; ZooKeeper implementation resolves via
+     * {@code LeaderSelector.getLeader()}.
+     */
+    default java.util.Optional<String> getLeaderNodeId() {
+        return java.util.Optional.empty();
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/NodeAddress.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/NodeAddress.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import java.util.Objects;
+
+/**
+ * Immutable value object identifying a cluster member by its node identifier
+ * and HTTP base URL (e.g. {@code https://node1:18443}).
+ */
+public final class NodeAddress {
+
+    private final String nodeId;
+    private final String baseUrl;
+
+    public NodeAddress(final String nodeId, final String baseUrl) {
+        this.nodeId = Objects.requireNonNull(nodeId, "nodeId is required");
+        this.baseUrl = Objects.requireNonNull(baseUrl, "baseUrl is required");
+    }
+
+    /** The logical node identifier (matches {@code nifi.registry.cluster.node.identifier}). */
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    /** The HTTP base URL used for inter-node replication (e.g. {@code https://node1:18443}). */
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final NodeAddress that = (NodeAddress) o;
+        return Objects.equals(nodeId, that.nodeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeId);
+    }
+
+    @Override
+    public String toString() {
+        return "NodeAddress{nodeId='" + nodeId + "', baseUrl='" + baseUrl + "'}";
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/NodeRegistry.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/NodeRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Maintains the live membership of the NiFi Registry cluster and provides
+ * address look-ups used by the write-replication path.
+ *
+ * <p>In ZooKeeper mode ({@code nifi.registry.cluster.coordination=zookeeper})
+ * the active implementation ({@link ZkNodeRegistry}) registers this node as
+ * an ephemeral ZNode on startup and watches for membership changes via
+ * {@code CuratorCache}.
+ */
+public interface NodeRegistry {
+
+    /** Returns this node's configured identifier. */
+    String getSelfNodeId();
+
+    /** Returns this node's HTTP base URL (e.g. {@code https://node1:18443}). */
+    String getSelfBaseUrl();
+
+    /** Returns addresses of all currently live cluster members including this node. */
+    List<NodeAddress> getAllNodes();
+
+    /**
+     * Returns addresses of all live cluster members <em>except</em> this node.
+     * Used by the leader when fanning out writes to followers.
+     */
+    List<NodeAddress> getOtherNodes();
+
+    /**
+     * Returns the address of the current cluster leader, or empty if the
+     * leader is unknown (e.g. during startup or a ZK session loss).
+     */
+    Optional<NodeAddress> getLeaderAddress();
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ReplicationClient.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ReplicationClient.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles inter-node HTTP communication for write replication.
+ *
+ * <p>Write routing uses HTTP 307 redirects rather than server-side proxying.
+ * When a follower receives a write it returns 307 with a {@code Location} header
+ * pointing to the leader so the client re-sends its request directly, preserving
+ * any TLS/mTLS client identity end-to-end.
+ *
+ * <p>This interface covers only the leader-to-follower fan-out direction, which
+ * uses the shared internal auth token and does not carry client credentials.
+ */
+public interface ReplicationClient {
+
+    /**
+     * Fans out the write described by {@code path}, {@code method},
+     * {@code headers}, and {@code body} to each node in {@code followers}.
+     *
+     * <p>Each follower is contacted asynchronously on a background thread.
+     * Failures are logged but do not block the caller; the leader's response
+     * has already been sent to the client before this method is called.
+     *
+     * @param path      request path including any query string
+     *                  (e.g. {@code /nifi-registry-api/buckets?param=value})
+     * @param method    HTTP method (e.g. {@code POST}, {@code DELETE})
+     * @param headers   original request headers to forward (hop-by-hop headers
+     *                  are filtered out by the implementation)
+     * @param body      request body bytes (may be empty)
+     * @param followers destination nodes; must not include this node
+     */
+    void replicateToFollowers(String path, String method,
+                               Map<String, String> headers, byte[] body,
+                               List<NodeAddress> followers);
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ReplicationConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ReplicationConfiguration.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.net.InetAddress;
+
+/**
+ * Creates the {@link NodeRegistry} and {@link ReplicationClient} beans used
+ * by the write-replication filter in the web layer.
+ *
+ * <p>Both beans are only active in ZooKeeper cluster mode
+ * ({@code nifi.registry.cluster.coordination=zookeeper}). In all other modes
+ * ({@code database} or standalone) {@code null} is returned so the filter
+ * passes every request through unchanged.
+ *
+ * <p>{@code @ConditionalOnProperty} is intentionally <em>not</em> used here
+ * because {@link NiFiRegistryProperties} is not exposed to the Spring
+ * {@code Environment} (it is loaded before the Spring context via the
+ * bootstrap mechanism). Factory-bean pattern with direct property checks is
+ * used throughout the codebase instead.
+ */
+@Configuration
+@Import(ZkClientFactory.class)
+public class ReplicationConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationConfiguration.class);
+
+    @Autowired
+    private NiFiRegistryProperties properties;
+
+    @Autowired
+    private LeaderElectionManager leaderElectionManager;
+
+    /**
+     * Provides the ZK-backed node registry when in ZooKeeper cluster mode,
+     * or {@code null} (no-op) otherwise.
+     */
+    @Bean
+    public NodeRegistry nodeRegistry(final ObjectProvider<CuratorFramework> curatorProvider) {
+        if (!properties.isClusterEnabled() || !properties.isZooKeeperCoordination()) {
+            LOGGER.debug("NodeRegistry not created: ZooKeeper coordination is not enabled.");
+            return null;
+        }
+
+        final String selfNodeId = resolveSelfNodeId();
+        final String selfBaseUrl = properties.getClusterNodeAddress();
+        if (StringUtils.isBlank(selfBaseUrl)) {
+            LOGGER.warn("NodeRegistry not created: '{}' is not configured. "
+                    + "Set nifi.registry.cluster.node.address in nifi-registry.properties.",
+                    NiFiRegistryProperties.CLUSTER_NODE_ADDRESS);
+            return null;
+        }
+
+        final CuratorFramework curator = curatorProvider.getObject();
+        final ZkNodeRegistry registry = new ZkNodeRegistry(
+                curator,
+                properties.getZooKeeperRootNode(),
+                selfNodeId,
+                selfBaseUrl,
+                leaderElectionManager);
+        registry.start();
+        return registry;
+    }
+
+    /**
+     * Provides the HTTP replication client when in ZooKeeper cluster mode,
+     * or {@code null} otherwise.
+     */
+    @Bean
+    public ReplicationClient replicationClient() {
+        if (!properties.isClusterEnabled() || !properties.isZooKeeperCoordination()) {
+            LOGGER.debug("ReplicationClient not created: ZooKeeper coordination is not enabled.");
+            return null;
+        }
+
+        final String authToken = properties.getClusterNodeInternalAuthToken();
+        if (StringUtils.isBlank(authToken)) {
+            LOGGER.warn("ReplicationClient not created: '{}' is not configured. "
+                    + "Set nifi.registry.cluster.node.internal.auth.token in nifi-registry.properties.",
+                    NiFiRegistryProperties.CLUSTER_NODE_INTERNAL_AUTH_TOKEN);
+            return null;
+        }
+
+        return new HttpReplicationClient(authToken);
+    }
+
+    private String resolveSelfNodeId() {
+        final String configured = properties.getClusterNodeIdentifier();
+        if (!StringUtils.isBlank(configured)) {
+            return configured;
+        }
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to resolve hostname; using 'unknown' as node identifier.", e);
+            return "unknown";
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ZkClientFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ZkClientFactory.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Creates and starts the {@link CuratorFramework} client used by
+ * {@link ZkLeaderElectionManager} when
+ * {@code nifi.registry.cluster.coordination=zookeeper}.
+ *
+ * <p>The bean is only produced when ZooKeeper coordination is active (checked
+ * inside the factory method so we can give a clear error message). It is the
+ * caller's responsibility ({@link LeaderElectionConfiguration}) to only
+ * request this bean in the appropriate mode.
+ */
+@Configuration
+public class ZkClientFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZkClientFactory.class);
+
+    /**
+     * Builds, starts, and returns a {@link CuratorFramework} connected to the
+     * ZooKeeper ensemble specified by {@code nifi.registry.zookeeper.connect.string}.
+     *
+     * <p>The returned client is started here; callers should close it via
+     * {@link LeaderElectionConfiguration} / {@link ZkLeaderElectionManager#destroy()}.
+     *
+     * <p>The bean is declared {@code @Lazy} so that it is only instantiated when
+     * first requested. In database-coordination or standalone mode no component
+     * requests this bean, so it is never created and a blank connect string
+     * does not cause a startup failure.
+     */
+    @Lazy
+    @Bean(destroyMethod = "close")
+    public CuratorFramework curatorFramework(final NiFiRegistryProperties properties) {
+        final String connectString = properties.getZooKeeperConnectString();
+        if (StringUtils.isBlank(connectString)) {
+            throw new IllegalStateException(
+                    NiFiRegistryProperties.ZOOKEEPER_CONNECT_STRING + " must be set when "
+                    + NiFiRegistryProperties.CLUSTER_COORDINATION + "="
+                    + NiFiRegistryProperties.CLUSTER_COORDINATION_ZOOKEEPER);
+        }
+
+        final int sessionTimeoutMs = (int) properties.getZooKeeperSessionTimeoutMs();
+        final int connectTimeoutMs = (int) properties.getZooKeeperConnectTimeoutMs();
+
+        if (properties.isZooKeeperClientSecure()) {
+            applyTlsSystemProperties(properties);
+        }
+
+        // RetryNTimes(1, 100) mirrors NiFi's createClient() — we prefer fast
+        // failure so that startup does not hang if ZooKeeper is unreachable.
+        final RetryPolicy retryPolicy = new RetryNTimes(1, 100);
+
+        LOGGER.info("Creating CuratorFramework: connectString={} sessionTimeout={}ms connectTimeout={}ms tls={}",
+                connectString, sessionTimeoutMs, connectTimeoutMs, properties.isZooKeeperClientSecure());
+
+        final CuratorFramework client = CuratorFrameworkFactory.builder()
+                .connectString(connectString)
+                .sessionTimeoutMs(sessionTimeoutMs)
+                .connectionTimeoutMs(connectTimeoutMs)
+                .retryPolicy(retryPolicy)
+                .defaultData(new byte[0])
+                .build();
+
+        client.start();
+        LOGGER.info("CuratorFramework started.");
+        return client;
+    }
+
+    /**
+     * Configures ZooKeeper TLS by setting the standard {@code zookeeper.ssl.*}
+     * and {@code zookeeper.client.secure} system properties before the
+     * {@code CuratorFramework} is constructed.
+     *
+     * <p>ZooKeeper 3.5.5+ reads these properties at client creation time via
+     * {@code ZKClientConfig}. Setting them as JVM system properties is the
+     * canonical approach used by Apache NiFi.
+     *
+     * <p>Note: these are process-wide properties. In normal NiFi Registry
+     * deployments there is exactly one ZooKeeper client per JVM so this is safe.
+     */
+    private static void applyTlsSystemProperties(final NiFiRegistryProperties properties) {
+        LOGGER.info("Enabling ZooKeeper TLS (zookeeper.client.secure=true).");
+        System.setProperty("zookeeper.client.secure", "true");
+        // Netty transport is required for TLS; the default NIO transport does not support it.
+        System.setProperty("zookeeper.clientCnxnSocket", "org.apache.zookeeper.ClientCnxnSocketNetty");
+
+        final String keystore = properties.getZooKeeperSecurityKeystore();
+        if (!StringUtils.isBlank(keystore)) {
+            System.setProperty("zookeeper.ssl.keyStore.location", keystore);
+        }
+        final String keystorePasswd = properties.getZooKeeperSecurityKeystorePasswd();
+        if (!StringUtils.isBlank(keystorePasswd)) {
+            System.setProperty("zookeeper.ssl.keyStore.password", keystorePasswd);
+        }
+        final String keystoreType = properties.getZooKeeperSecurityKeystoreType();
+        if (!StringUtils.isBlank(keystoreType)) {
+            System.setProperty("zookeeper.ssl.keyStore.type", keystoreType);
+        }
+
+        final String truststore = properties.getZooKeeperSecurityTruststore();
+        if (!StringUtils.isBlank(truststore)) {
+            System.setProperty("zookeeper.ssl.trustStore.location", truststore);
+        }
+        final String truststorePasswd = properties.getZooKeeperSecurityTruststorePasswd();
+        if (!StringUtils.isBlank(truststorePasswd)) {
+            System.setProperty("zookeeper.ssl.trustStore.password", truststorePasswd);
+        }
+        final String truststoreType = properties.getZooKeeperSecurityTruststoreType();
+        if (!StringUtils.isBlank(truststoreType)) {
+            System.setProperty("zookeeper.ssl.trustStore.type", truststoreType);
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ZkLeaderElectionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ZkLeaderElectionManager.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderSelector;
+import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.curator.framework.recipes.leader.Participant;
+
+/**
+ * ZooKeeper-backed implementation of {@link LeaderElectionManager}.
+ *
+ * <p>Uses Apache Curator's {@link LeaderSelector} with {@code autoRequeue()} so
+ * this node continuously participates in the election. The exact same pattern
+ * used by NiFi's {@code CuratorLeaderElectionManager} is followed here:
+ *
+ * <ul>
+ *   <li>Leadership is held as long as {@link ElectionListener#takeLeadership} is
+ *       blocking. Returning from that method yields leadership back to Curator.</li>
+ *   <li>On {@code SUSPENDED} or {@code LOST} connection state the leader flag is
+ *       immediately cleared — the node never claims leadership without a live
+ *       ZooKeeper session.</li>
+ *   <li>{@link #isLeader()} verifies against ZooKeeper at most every
+ *       {@value #VERIFY_CACHE_MS} ms to catch cases where Curator fails to
+ *       interrupt the leader thread.</li>
+ * </ul>
+ *
+ * <p>ZNode path: {@code <rootNode>/leaders/registry-leader}
+ *
+ * <p>This class is instantiated by {@link LeaderElectionConfiguration} when
+ * {@code nifi.registry.cluster.coordination=zookeeper}.
+ */
+public class ZkLeaderElectionManager implements LeaderElectionManager, DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZkLeaderElectionManager.class);
+
+    static final String ELECTION_PATH_SUFFIX = "leaders/registry-leader";
+
+    /** How long {@link #isLeader()} caches the ZooKeeper-verified result (ms). */
+    static final long VERIFY_CACHE_MS = TimeUnit.SECONDS.toMillis(5);
+
+    private final String nodeId;
+    private final String electionPath;
+    private final List<LeaderChangeListener> listeners = new CopyOnWriteArrayList<>();
+
+    private final ElectionListener electionListener;
+    private final LeaderSelector leaderSelector;
+
+    public ZkLeaderElectionManager(final CuratorFramework curatorClient,
+            final NiFiRegistryProperties properties) {
+        this.nodeId = resolveNodeId(properties);
+
+        final String root = properties.getZooKeeperRootNode();
+        this.electionPath = root + (root.endsWith("/") ? "" : "/") + ELECTION_PATH_SUFFIX;
+
+        this.electionListener = new ElectionListener();
+        this.leaderSelector = new LeaderSelector(curatorClient, electionPath, electionListener);
+        this.leaderSelector.autoRequeue();
+        this.leaderSelector.setId(nodeId);
+    }
+
+    public void start() {
+        LOGGER.info("Starting ZkLeaderElectionManager for node '{}' at path '{}'.", nodeId, electionPath);
+        leaderSelector.start();
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("Shutting down ZkLeaderElectionManager.");
+        electionListener.disable();
+        try {
+            leaderSelector.close();
+        } catch (final Exception e) {
+            LOGGER.debug("Exception closing LeaderSelector (expected if not started)", e);
+        }
+    }
+
+    @Override
+    public boolean isLeader() {
+        return electionListener.isLeader();
+    }
+
+    @Override
+    public void addLeaderChangeListener(final LeaderChangeListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public Optional<String> getLeaderNodeId() {
+        try {
+            final Participant leader = leaderSelector.getLeader();
+            if (leader == null || StringUtils.isEmpty(leader.getId())) {
+                return Optional.empty();
+            }
+            return Optional.of(leader.getId());
+        } catch (final Exception e) {
+            LOGGER.debug("Unable to resolve leader node ID from ZooKeeper: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private void notifyStartLeading() {
+        for (final LeaderChangeListener l : listeners) {
+            try {
+                l.onStartLeading();
+            } catch (final Exception e) {
+                LOGGER.error("LeaderChangeListener threw on onStartLeading()", e);
+            }
+        }
+    }
+
+    private void notifyStopLeading() {
+        for (final LeaderChangeListener l : listeners) {
+            try {
+                l.onStopLeading();
+            } catch (final Exception e) {
+                LOGGER.error("LeaderChangeListener threw on onStopLeading()", e);
+            }
+        }
+    }
+
+    /**
+     * Asks ZooKeeper directly who the current leader is and returns whether it
+     * matches this node's id.
+     */
+    private boolean verifyLeaderWithZk() {
+        try {
+            final org.apache.curator.framework.recipes.leader.Participant leader =
+                    leaderSelector.getLeader();
+            if (leader == null || StringUtils.isEmpty(leader.getId())) {
+                return false;
+            }
+            return nodeId.equals(leader.getId());
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to verify leadership with ZooKeeper for node '{}': {}", nodeId, e.getMessage());
+            return false;
+        }
+    }
+
+    private static String resolveNodeId(final NiFiRegistryProperties props) {
+        final String configured = props.getClusterNodeIdentifier();
+        if (!StringUtils.isBlank(configured)) {
+            return configured;
+        }
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to resolve hostname for node identifier; using 'unknown'", e);
+            return "unknown";
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner class: ElectionListener — mirrors NiFi's CuratorLeaderElectionManager.ElectionListener
+    // -------------------------------------------------------------------------
+
+    private class ElectionListener extends LeaderSelectorListenerAdapter {
+
+        private volatile boolean leader = false;
+        private volatile boolean disabled = false;
+        private volatile Thread leaderThread;
+
+        /** Timestamp of the last ZooKeeper-verified isLeader() call. */
+        private long verifyTimestamp = 0L;
+
+        /** Disable election participation (called on shutdown). */
+        void disable() {
+            disabled = true;
+            setLeader(false);
+            final Thread t = leaderThread;
+            if (t != null) {
+                t.interrupt();
+            }
+        }
+
+        synchronized boolean isLeader() {
+            if (!leader) {
+                return false;
+            }
+            // Re-verify against ZooKeeper if the cache has expired.
+            if (System.currentTimeMillis() - verifyTimestamp > VERIFY_CACHE_MS) {
+                final boolean verified = verifyLeaderWithZk();
+                setLeader(verified);
+            }
+            return leader;
+        }
+
+        private synchronized void setLeader(final boolean value) {
+            this.leader = value;
+            this.verifyTimestamp = System.currentTimeMillis();
+        }
+
+        @Override
+        public synchronized void stateChanged(final CuratorFramework client,
+                final ConnectionState newState) {
+            LOGGER.info("ZooKeeper connection state changed to {} for node '{}'.", newState, nodeId);
+            if (newState == ConnectionState.SUSPENDED || newState == ConnectionState.LOST) {
+                if (leader) {
+                    LOGGER.warn("Node '{}' relinquishing leadership due to ZooKeeper connection state {}.", nodeId, newState);
+                }
+                setLeader(false);
+            }
+            super.stateChanged(client, newState);
+        }
+
+        /**
+         * Curator calls this method on the node that has been elected leader.
+         * We must block here for as long as we wish to remain leader. Returning
+         * (or throwing) yields leadership back to the next candidate.
+         */
+        @Override
+        public void takeLeadership(final CuratorFramework client) throws Exception {
+            if (disabled) {
+                return;
+            }
+
+            leaderThread = Thread.currentThread();
+            setLeader(true);
+            LOGGER.info("Node '{}' has been elected cluster leader.", nodeId);
+
+            notifyStartLeading();
+
+            // Verify with ZooKeeper periodically while we hold leadership.
+            // Every 50 * 100 ms = 5 seconds, matching NiFi's pattern.
+            try {
+                int loopCount = 0;
+                int failureCount = 0;
+                while (!disabled && leader) {
+                    try {
+                        Thread.sleep(100L);
+                    } catch (final InterruptedException ie) {
+                        LOGGER.info("Node '{}' leader thread interrupted; relinquishing leadership.", nodeId);
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+
+                    if (++loopCount % 50 == 0) {
+                        try {
+                            if (!verifyLeaderWithZk()) {
+                                LOGGER.info("ZooKeeper reports node '{}' is no longer the leader; relinquishing.", nodeId);
+                                break;
+                            }
+                            failureCount = 0;
+                        } catch (final Exception e) {
+                            failureCount++;
+                            if (failureCount > 1) {
+                                LOGGER.warn("Node '{}' failed ZooKeeper leadership verification twice; relinquishing.", nodeId, e);
+                                break;
+                            } else {
+                                LOGGER.warn("Node '{}' failed ZooKeeper leadership verification; will retry once.", nodeId, e);
+                            }
+                        }
+                    }
+                }
+            } finally {
+                setLeader(false);
+                LOGGER.info("Node '{}' is no longer cluster leader.", nodeId);
+                notifyStopLeading();
+                leaderThread = null;
+            }
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ZkNodeRegistry.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/cluster/ZkNodeRegistry.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * ZooKeeper-backed implementation of {@link NodeRegistry}.
+ *
+ * <p>Each cluster member registers itself as an <em>ephemeral</em> ZNode at
+ * {@code <rootNode>/members/<nodeId>} with the node's HTTP base URL as the
+ * node data. Ephemeral nodes are automatically removed by ZooKeeper when the
+ * session expires, giving us free liveness detection.
+ *
+ * <p>A {@code CuratorCache} watches the {@code /members} subtree so the local
+ * membership map is kept up-to-date in real time.
+ *
+ * <p>This class is instantiated by {@link ReplicationConfiguration} when
+ * {@code nifi.registry.cluster.coordination=zookeeper}.
+ */
+public class ZkNodeRegistry implements NodeRegistry, DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZkNodeRegistry.class);
+
+    private final CuratorFramework client;
+    private final String selfNodeId;
+    private final String selfBaseUrl;
+    private final String membersPath;
+    private final LeaderElectionManager leaderElectionManager;
+
+    /** Live membership: nodeId → base URL. Updated by the CuratorCache listener. */
+    private final ConcurrentHashMap<String, String> members = new ConcurrentHashMap<>();
+
+    private CuratorCache memberCache;
+
+    public ZkNodeRegistry(final CuratorFramework client,
+            final String rootNode,
+            final String selfNodeId,
+            final String selfBaseUrl,
+            final LeaderElectionManager leaderElectionManager) {
+        this.client = client;
+        this.selfNodeId = selfNodeId;
+        this.selfBaseUrl = selfBaseUrl;
+        this.membersPath = rootNode + (rootNode.endsWith("/") ? "" : "/") + "members";
+        this.leaderElectionManager = leaderElectionManager;
+    }
+
+    public void start() {
+        LOGGER.info("ZkNodeRegistry starting: registering node '{}' at {} under '{}'.",
+                selfNodeId, selfBaseUrl, membersPath);
+
+        // 1. Seed the local map with the current ZK snapshot, then register self.
+        loadInitialMembers();
+        registerSelf();
+
+        // 2. CuratorCache keeps the map current for subsequent changes.
+        memberCache = CuratorCache.build(client, membersPath);
+        memberCache.listenable().addListener(this::onMemberEvent);
+        memberCache.start();
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("ZkNodeRegistry shutting down for node '{}'.", selfNodeId);
+        if (memberCache != null) {
+            try {
+                memberCache.close();
+            } catch (final Exception e) {
+                LOGGER.debug("Exception closing CuratorCache", e);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // NodeRegistry
+    // -------------------------------------------------------------------------
+
+    @Override
+    public String getSelfNodeId() {
+        return selfNodeId;
+    }
+
+    @Override
+    public String getSelfBaseUrl() {
+        return selfBaseUrl;
+    }
+
+    @Override
+    public List<NodeAddress> getAllNodes() {
+        return members.entrySet().stream()
+                .map(e -> new NodeAddress(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    @Override
+    public List<NodeAddress> getOtherNodes() {
+        return members.entrySet().stream()
+                .filter(e -> !selfNodeId.equals(e.getKey()))
+                .map(e -> new NodeAddress(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    @Override
+    public Optional<NodeAddress> getLeaderAddress() {
+        return leaderElectionManager.getLeaderNodeId()
+                .flatMap(leaderId -> Optional.ofNullable(members.get(leaderId))
+                        .map(url -> new NodeAddress(leaderId, url)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private void registerSelf() {
+        final String path = membersPath + "/" + selfNodeId;
+        final byte[] data = selfBaseUrl.getBytes(StandardCharsets.UTF_8);
+        try {
+            client.create()
+                    .creatingParentsIfNeeded()
+                    .withMode(CreateMode.EPHEMERAL)
+                    .forPath(path, data);
+            members.put(selfNodeId, selfBaseUrl);
+        } catch (final NodeExistsException e) {
+            // Can happen if previous session's ephemeral node hasn't expired yet.
+            try {
+                client.setData().forPath(path, data);
+                members.put(selfNodeId, selfBaseUrl);
+            } catch (final Exception ex) {
+                LOGGER.warn("Failed to update stale member node for '{}': {}", selfNodeId, ex.getMessage());
+            }
+        } catch (final Exception e) {
+            LOGGER.error("Failed to register member node for '{}': {}", selfNodeId, e.getMessage());
+        }
+    }
+
+    private void loadInitialMembers() {
+        try {
+            for (final String childId : client.getChildren().forPath(membersPath)) {
+                try {
+                    final byte[] data = client.getData().forPath(membersPath + "/" + childId);
+                    if (data != null && data.length > 0) {
+                        members.put(childId, new String(data, StandardCharsets.UTF_8));
+                    }
+                } catch (final Exception e) {
+                    LOGGER.debug("Skipping member node '{}' during initial load: {}", childId, e.getMessage());
+                }
+            }
+        } catch (final Exception e) {
+            // Path may not exist yet if this is the first node.
+            LOGGER.debug("Members path '{}' does not exist yet; starting with empty membership.", membersPath);
+        }
+    }
+
+    private void onMemberEvent(final CuratorCacheListener.Type type,
+            final ChildData oldData, final ChildData newData) {
+        switch (type) {
+            case NODE_CREATED, NODE_CHANGED -> {
+                if (newData != null && newData.getData() != null && newData.getData().length > 0) {
+                    final String nodeId = extractNodeId(newData.getPath());
+                    if (!nodeId.isEmpty()) {
+                        final String baseUrl = new String(newData.getData(), StandardCharsets.UTF_8);
+                        members.put(nodeId, baseUrl);
+                        LOGGER.info("Cluster member registered/updated: '{}' at {}.", nodeId, baseUrl);
+                    }
+                }
+            }
+            case NODE_DELETED -> {
+                if (oldData != null) {
+                    final String nodeId = extractNodeId(oldData.getPath());
+                    if (!nodeId.isEmpty()) {
+                        members.remove(nodeId);
+                        LOGGER.info("Cluster member removed: '{}'.", nodeId);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts the last path segment — the nodeId — from a ZNode path like
+     * {@code /nifi-registry/members/<nodeId>}. Returns empty string for the
+     * parent path itself (which CuratorCache also fires events for).
+     */
+    private String extractNodeId(final String path) {
+        if (path == null || path.equals(membersPath)) {
+            return "";
+        }
+        final int lastSlash = path.lastIndexOf('/');
+        return lastSlash >= 0 ? path.substring(lastSlash + 1) : "";
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/DataSyncBootstrapper.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/DataSyncBootstrapper.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.db;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeAddress;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Synchronises the local H2 database from the cluster leader when a node
+ * starts up with an empty database.
+ *
+ * <p>This bean is active only when ZooKeeper cluster coordination is enabled
+ * ({@code nifi.registry.cluster.coordination=zookeeper}). On every startup
+ * it checks whether the local database is empty (zero rows in the
+ * {@code BUCKET} table). If so, and if this node is not the elected leader,
+ * it:
+ * <ol>
+ *   <li>Waits up to {@value #LEADER_WAIT_TIMEOUT_MS} ms for a leader to be
+ *       elected and registered in ZooKeeper.</li>
+ *   <li>Calls {@code GET /nifi-registry-api/internal/sync/export} on the
+ *       leader with the shared internal auth token.</li>
+ *   <li>Applies the returned H2 SQL script via {@code RUNSCRIPT FROM}.</li>
+ * </ol>
+ *
+ * <p>If the sync fails (leader unreachable, timeout, etc.) the node continues
+ * with its empty database. Data will populate organically as write operations
+ * are replicated to this node by {@link
+ * org.apache.nifi.registry.web.security.replication.WriteReplicationFilter}.
+ *
+ * <p>This is intentionally H2-only. Operators using PostgreSQL or MySQL have
+ * a shared database and do not need this sync.
+ */
+@Component
+public class DataSyncBootstrapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSyncBootstrapper.class);
+
+    static final long LEADER_WAIT_TIMEOUT_MS = 30_000L;
+    static final long LEADER_POLL_INTERVAL_MS = 1_000L;
+    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration HTTP_REQUEST_TIMEOUT = Duration.ofSeconds(120);
+
+    private final NiFiRegistryProperties properties;
+    private final DataSource dataSource;
+    private final LeaderElectionManager leaderElectionManager;
+    private final NodeRegistry nodeRegistry; // null in non-ZK modes
+
+    @Autowired
+    public DataSyncBootstrapper(final NiFiRegistryProperties properties,
+            final DataSource dataSource,
+            final LeaderElectionManager leaderElectionManager,
+            @Autowired(required = false) final NodeRegistry nodeRegistry) {
+        this.properties = properties;
+        this.dataSource = dataSource;
+        this.leaderElectionManager = leaderElectionManager;
+        this.nodeRegistry = nodeRegistry;
+    }
+
+    @PostConstruct
+    public void syncFromLeaderIfNeeded() {
+        if (!properties.isClusterEnabled() || !properties.isZooKeeperCoordination()) {
+            return;
+        }
+        if (nodeRegistry == null) {
+            return;
+        }
+        if (leaderElectionManager.isLeader()) {
+            LOGGER.info("DataSyncBootstrapper: this node is the leader; skipping bootstrap sync.");
+            return;
+        }
+        if (!isLocalDbH2()) {
+            LOGGER.debug("DataSyncBootstrapper: database is not H2; skipping bootstrap sync.");
+            return;
+        }
+        if (!isLocalDbEmpty()) {
+            LOGGER.info("DataSyncBootstrapper: local database has existing data; skipping bootstrap sync.");
+            return;
+        }
+
+        LOGGER.info("DataSyncBootstrapper: local H2 database is empty and this node is a follower. "
+                + "Initiating bootstrap sync from leader.");
+
+        final String authToken = properties.getClusterNodeInternalAuthToken();
+        if (authToken == null || authToken.isBlank()) {
+            LOGGER.warn("DataSyncBootstrapper: '{}' is not configured. "
+                    + "Skipping bootstrap sync to avoid repeated 403 errors. "
+                    + "This node will start with an empty database and populate via write replication.",
+                    "nifi.registry.cluster.node.internal.auth.token");
+            return;
+        }
+
+        final NodeAddress leader = waitForLeader();
+        if (leader == null) {
+            LOGGER.warn("DataSyncBootstrapper: no leader elected within {}ms. "
+                    + "This node will start with an empty database and populate via write replication.",
+                    LEADER_WAIT_TIMEOUT_MS);
+            return;
+        }
+
+        // Re-check: this node may have won the election while waiting.
+        if (leaderElectionManager.isLeader()) {
+            LOGGER.info("DataSyncBootstrapper: this node became leader during the wait; skipping bootstrap sync.");
+            return;
+        }
+
+        LOGGER.info("DataSyncBootstrapper: syncing database snapshot from leader '{}'.", leader.getNodeId());
+        try {
+            final String script = fetchExportScript(leader);
+            applyScript(script);
+            LOGGER.info("DataSyncBootstrapper: bootstrap sync from leader '{}' completed successfully.",
+                    leader.getNodeId());
+        } catch (final Exception e) {
+            LOGGER.error("DataSyncBootstrapper: bootstrap sync from leader '{}' failed: {}. "
+                    + "This node will start with an empty database.",
+                    leader.getNodeId(), e.getMessage(), e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private boolean isLocalDbH2() {
+        try (Connection conn = dataSource.getConnection()) {
+            return conn.getMetaData().getDatabaseProductName().contains("H2");
+        } catch (final Exception e) {
+            LOGGER.debug("DataSyncBootstrapper: could not determine database type.", e);
+            return false;
+        }
+    }
+
+    private boolean isLocalDbEmpty() {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM BUCKET")) {
+            if (rs.next()) {
+                return rs.getInt(1) == 0;
+            }
+            return true;
+        } catch (final Exception e) {
+            LOGGER.debug("DataSyncBootstrapper: could not count BUCKET rows; assuming non-empty.", e);
+            return false;
+        }
+    }
+
+    private NodeAddress waitForLeader() {
+        final long deadline = System.currentTimeMillis() + LEADER_WAIT_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            final Optional<NodeAddress> leader = nodeRegistry.getLeaderAddress();
+            if (leader.isPresent()) {
+                return leader.get();
+            }
+            try {
+                Thread.sleep(LEADER_POLL_INTERVAL_MS);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private String fetchExportScript(final NodeAddress leader) throws IOException, InterruptedException {
+        final String url = leader.getBaseUrl() + "/nifi-registry-api/internal/sync/export";
+        LOGGER.debug("DataSyncBootstrapper: requesting export from {}.", url);
+
+        final HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(HTTP_CONNECT_TIMEOUT)
+                .build();
+
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("X-Registry-Internal-Auth", properties.getClusterNodeInternalAuthToken())
+                .GET()
+                .timeout(HTTP_REQUEST_TIMEOUT)
+                .build();
+
+        final HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+        if (response.statusCode() != 200) {
+            throw new IOException("Leader returned HTTP " + response.statusCode()
+                    + " for export request (body: " + response.body() + ")");
+        }
+        return response.body();
+    }
+
+    private void applyScript(final String script) throws Exception {
+        // Write to a temp file because H2's RUNSCRIPT command takes a file path.
+        final Path tempFile = Files.createTempFile("registry-bootstrap-", ".sql");
+        try {
+            Files.writeString(tempFile, script, StandardCharsets.UTF_8);
+
+            // Escape backslashes on Windows paths.
+            final String safePath = tempFile.toAbsolutePath().toString().replace("\\", "/");
+            LOGGER.debug("DataSyncBootstrapper: applying script from temp file: {}", safePath);
+
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("RUNSCRIPT FROM '" + safePath + "'");
+            }
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/ClusterAwareEventService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/ClusterAwareEventService.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.apache.nifi.registry.cluster.LeaderChangeListener;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.hook.Event;
+import org.apache.nifi.registry.hook.EventField;
+import org.apache.nifi.registry.hook.EventHookProvider;
+import org.apache.nifi.registry.hook.EventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+
+/**
+ * Cluster-aware implementation of {@link EventService}.
+ *
+ * <p>Events published by <em>any</em> cluster node are persisted to the
+ * {@code REGISTRY_EVENT} database table. Only the current leader node delivers
+ * events to {@link EventHookProvider}s.
+ *
+ * <p>Delivery is performed in a background loop with retries, providing
+ * at-least-once semantics for each event. If a delivery attempt fails for any
+ * provider, the event may be retried and therefore re-delivered to providers
+ * that have already processed it. {@link EventHookProvider} implementations
+ * must be idempotent and tolerate duplicate deliveries.
+ *
+ * <p>The delivery loop runs every 5 seconds. Processed events are retained for
+ * {@value #RETENTION_DAYS} days before being purged.
+ *
+ * <p>This implementation is selected when {@code nifi.registry.cluster.enabled=true}.
+ * It is instantiated by {@link EventServiceConfiguration}.
+ */
+public class ClusterAwareEventService implements EventService, DisposableBean, LeaderChangeListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterAwareEventService.class);
+
+    /** How often the leader polls for unprocessed events (milliseconds). */
+    static final long DELIVERY_POLL_INTERVAL_MS = 5_000L;
+
+    /** Processed events older than this many days are deleted. */
+    static final int RETENTION_DAYS = 7;
+
+    /** Maximum number of delivery attempts before an event is discarded with a WARN log. */
+    static final int MAX_RETRY_COUNT = 3;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final LeaderElectionManager leaderElectionManager;
+    private final List<EventHookProvider> eventHookProviders;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ScheduledExecutorService deliveryScheduler;
+
+    public ClusterAwareEventService(final List<EventHookProvider> eventHookProviders,
+            final DataSource dataSource,
+            final LeaderElectionManager leaderElectionManager) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.leaderElectionManager = leaderElectionManager;
+        this.eventHookProviders = new ArrayList<>(eventHookProviders);
+    }
+
+    @PostConstruct
+    public void start() {
+        LOGGER.info("Starting ClusterAwareEventService delivery loop.");
+        deliveryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread t = new Thread(r, "ClusterEventDelivery");
+            t.setDaemon(true);
+            return t;
+        });
+        deliveryScheduler.scheduleWithFixedDelay(
+                this::deliverPendingEvents,
+                DELIVERY_POLL_INTERVAL_MS, DELIVERY_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+        // Register for leader-change callbacks (no-op for DatabaseLeaderElectionManager).
+        leaderElectionManager.addLeaderChangeListener(this);
+    }
+
+    // -------------------------------------------------------------------------
+    // LeaderChangeListener
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void onStartLeading() {
+        LOGGER.info("This node became cluster leader; triggering immediate event delivery.");
+        // Submit to the delivery thread so we don't block the election thread
+        // and avoid concurrent delivery with the scheduled poll.
+        deliveryScheduler.submit(this::deliverPendingEvents);
+    }
+
+    @Override
+    public void onStopLeading() {
+        LOGGER.info("This node is no longer cluster leader; pausing event delivery.");
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("Shutting down ClusterAwareEventService.");
+        if (deliveryScheduler != null) {
+            deliveryScheduler.shutdownNow();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // EventService
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void publish(final Event event) {
+        if (event == null) {
+            return;
+        }
+
+        try {
+            event.validate();
+        } catch (final IllegalStateException e) {
+            LOGGER.error("Invalid event, discarding: {}", e.getMessage());
+            return;
+        }
+
+        final String json = serializeEvent(event);
+        if (json == null) {
+            return;
+        }
+
+        final String eventId = UUID.randomUUID().toString();
+        final Timestamp now = Timestamp.from(Instant.now());
+
+        jdbcTemplate.update(
+                "INSERT INTO REGISTRY_EVENT (EVENT_ID, EVENT_TYPE, EVENT_DATA, CREATED_AT, PROCESSED) VALUES (?, ?, ?, ?, FALSE)",
+                eventId, event.getEventType().name(), json, now);
+
+        LOGGER.debug("Persisted event {} of type {}.", eventId, event.getEventType());
+    }
+
+    // -------------------------------------------------------------------------
+    // Leader-only delivery loop
+    // -------------------------------------------------------------------------
+
+    // Package-private to allow direct invocation from unit tests without reflection.
+    void deliverPendingEvents() {
+        if (!leaderElectionManager.isLeader()) {
+            return;
+        }
+
+        try {
+            final List<PersistedEvent> pending = queryPendingEvents();
+            for (final PersistedEvent row : pending) {
+                try {
+                    final Event event = deserializeEvent(row.eventType, row.eventData);
+                    if (event == null) {
+                        // Malformed record: mark processed to prevent infinite retry.
+                        markProcessed(row.eventId);
+                        continue;
+                    }
+                    deliverToProviders(event);
+                    markProcessed(row.eventId);
+                } catch (final Exception eventException) {
+                    final int newRetryCount = row.retryCount + 1;
+                    incrementRetryCount(row.eventId);
+                    if (newRetryCount >= MAX_RETRY_COUNT) {
+                        LOGGER.warn("Discarding event after {} failed delivery attempts: id={} type={} data={}",
+                                MAX_RETRY_COUNT, row.eventId, row.eventType, row.eventData);
+                        markProcessed(row.eventId);
+                    } else {
+                        LOGGER.debug("Transient failure delivering event id={} type={} (attempt {}/{}): {}",
+                                row.eventId, row.eventType, newRetryCount, MAX_RETRY_COUNT, eventException.getMessage());
+                    }
+                }
+            }
+
+            purgeOldEvents();
+        } catch (final Exception e) {
+            LOGGER.error("Error during cluster event delivery", e);
+        }
+    }
+
+    private List<PersistedEvent> queryPendingEvents() {
+        return jdbcTemplate.query(
+                "SELECT EVENT_ID, EVENT_TYPE, EVENT_DATA, RETRY_COUNT FROM REGISTRY_EVENT WHERE PROCESSED = FALSE ORDER BY CREATED_AT",
+                (rs, rowNum) -> mapRow(rs));
+    }
+
+    private PersistedEvent mapRow(final ResultSet rs) throws SQLException {
+        return new PersistedEvent(
+                rs.getString("EVENT_ID"),
+                rs.getString("EVENT_TYPE"),
+                rs.getString("EVENT_DATA"),
+                rs.getInt("RETRY_COUNT"));
+    }
+
+    private void markProcessed(final String eventId) {
+        jdbcTemplate.update("UPDATE REGISTRY_EVENT SET PROCESSED = TRUE WHERE EVENT_ID = ?", eventId);
+    }
+
+    private void incrementRetryCount(final String eventId) {
+        jdbcTemplate.update("UPDATE REGISTRY_EVENT SET RETRY_COUNT = RETRY_COUNT + 1 WHERE EVENT_ID = ?", eventId);
+    }
+
+    private void purgeOldEvents() {
+        final Timestamp cutoff = Timestamp.from(Instant.now().minus(RETENTION_DAYS, ChronoUnit.DAYS));
+        final int deleted = jdbcTemplate.update(
+                "DELETE FROM REGISTRY_EVENT WHERE PROCESSED = TRUE AND CREATED_AT < ?", cutoff);
+        if (deleted > 0) {
+            LOGGER.debug("Purged {} processed event(s) older than {} days.", deleted, RETENTION_DAYS);
+        }
+    }
+
+    private void deliverToProviders(final Event event) {
+        final List<String> failures = new ArrayList<>();
+        for (final EventHookProvider provider : eventHookProviders) {
+            try {
+                if (event.getEventType() == null || provider.shouldHandle(event.getEventType())) {
+                    provider.handle(event);
+                }
+            } catch (final Exception e) {
+                LOGGER.debug("Event hook provider {} failed handling event type {}: {}",
+                        provider.getClass().getSimpleName(), event.getEventType(), e.getMessage());
+                failures.add(provider.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        }
+        if (!failures.isEmpty()) {
+            throw new RuntimeException(failures.size() + " event hook provider(s) failed: " + String.join("; ", failures));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON serialization / deserialization
+    // -------------------------------------------------------------------------
+
+    /**
+     * Serializes an {@link Event} to a JSON string of the form:
+     * <pre>{"eventType":"CREATE_BUCKET","fields":[{"name":"BUCKET_ID","value":"..."},...]}
+     * </pre>
+     */
+    private String serializeEvent(final Event event) {
+        try {
+            final EventRecord record = new EventRecord();
+            record.eventType = event.getEventType().name();
+            record.fields = new ArrayList<>();
+            for (final EventField field : event.getFields()) {
+                final FieldRecord fr = new FieldRecord();
+                fr.name = field.getName().name();
+                fr.value = field.getValue();
+                record.fields.add(fr);
+            }
+            return objectMapper.writeValueAsString(record);
+        } catch (final JsonProcessingException e) {
+            LOGGER.error("Failed to serialize event of type {}: {}", event.getEventType(), e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Deserializes a JSON string back to a {@link StandardEvent}.
+     * Returns {@code null} if the record is malformed.
+     */
+    private Event deserializeEvent(final String eventTypeName, final String json) {
+        try {
+            final EventType eventType = EventType.valueOf(eventTypeName);
+            final EventRecord record = objectMapper.readValue(json, EventRecord.class);
+
+            final StandardEvent.Builder builder = new StandardEvent.Builder().eventType(eventType);
+            for (final FieldRecord fr : record.fields) {
+                builder.addField(
+                        org.apache.nifi.registry.hook.EventFieldName.valueOf(fr.name),
+                        fr.value);
+            }
+            return builder.build();
+        } catch (final Exception e) {
+            LOGGER.error("Failed to deserialize event type='{}': {}", eventTypeName, e.getMessage());
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner types
+    // -------------------------------------------------------------------------
+
+    static class EventRecord {
+        public String eventType;
+        public List<FieldRecord> fields;
+    }
+
+    static class FieldRecord {
+        public String name;
+        public String value;
+    }
+
+    private static class PersistedEvent {
+        final String eventId;
+        final String eventType;
+        final String eventData;
+        final int retryCount;
+
+        PersistedEvent(final String eventId, final String eventType, final String eventData, final int retryCount) {
+            this.eventId = eventId;
+            this.eventType = eventType;
+            this.eventData = eventData;
+            this.retryCount = retryCount;
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventService.java
@@ -17,99 +17,30 @@
 package org.apache.nifi.registry.event;
 
 import org.apache.nifi.registry.hook.Event;
-import org.apache.nifi.registry.hook.EventHookProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import jakarta.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /**
- * Service used for publishing events and passing events to the hook providers.
+ * Service used for publishing events and passing them to configured hook providers.
+ *
+ * <p>In standalone mode (the default) a {@link StandardEventService} is used: events
+ * are queued in memory and delivered on a single background thread.
+ *
+ * <p>In cluster mode ({@code nifi.registry.cluster.enabled=true}) a
+ * {@link ClusterAwareEventService} is used: events are persisted to the
+ * {@code REGISTRY_EVENT} database table and delivered exactly once by the
+ * current leader node.
+ *
+ * <p>The active implementation is selected by {@link EventServiceConfiguration}.
  */
-@Service
-public class EventService implements DisposableBean {
+public interface EventService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EventService.class);
-
-    // Should only be a few events in the queue at a time, but setting a capacity just so it isn't unbounded
-    static final int EVENT_QUEUE_SIZE = 10_000;
-
-    private final BlockingQueue<Event> eventQueue;
-    private final ExecutorService scheduledExecutorService;
-    private final List<EventHookProvider> eventHookProviders;
-
-    @Autowired
-    public EventService(final List<EventHookProvider> eventHookProviders) {
-        this.eventQueue = new LinkedBlockingQueue<>(EVENT_QUEUE_SIZE);
-        this.scheduledExecutorService = Executors.newSingleThreadExecutor();
-        this.eventHookProviders = new ArrayList<>(eventHookProviders);
-    }
-
-    @PostConstruct
-    public void postConstruct() {
-        LOGGER.info("Starting event consumer...");
-
-        this.scheduledExecutorService.execute(() -> {
-            while (!Thread.interrupted()) {
-                try {
-                    final Event event = eventQueue.poll(1000, TimeUnit.MILLISECONDS);
-                    if (event == null) {
-                        continue;
-                    }
-
-                    // event was available so notify each provider, contain errors per-provider
-                    for (final EventHookProvider provider : eventHookProviders) {
-                        try {
-                            if (event.getEventType() == null
-                                    || (event.getEventType() != null && provider.shouldHandle(event.getEventType()))) {
-                                provider.handle(event);
-                            }
-                        } catch (Exception e) {
-                            LOGGER.error("Error handling event hook", e);
-                        }
-                    }
-                } catch (InterruptedException e) {
-                    LOGGER.warn("Interrupted while polling event queue");
-                    return;
-                }
-            }
-        });
-
-        LOGGER.info("Event consumer started!");
-    }
-
-    @Override
-    public void destroy() throws Exception {
-        LOGGER.info("Shutting down event consumer...");
-        this.scheduledExecutorService.shutdownNow();
-        LOGGER.info("Event consumer shutdown!");
-    }
-
-    public void publish(final Event event) {
-        if (event == null) {
-            return;
-        }
-
-        try {
-            event.validate();
-
-            final boolean queued = eventQueue.offer(event);
-            if (!queued) {
-                LOGGER.error("Unable to queue event because queue is full");
-            }
-        } catch (IllegalStateException e) {
-            LOGGER.error("Invalid event", e);
-        }
-    }
-
+    /**
+     * Publishes the given event for delivery to all configured
+     * {@link org.apache.nifi.registry.hook.EventHookProvider}s.
+     *
+     * <p>Null events and invalid events (those that fail {@link Event#validate()})
+     * are silently discarded.
+     *
+     * @param event the event to publish
+     */
+    void publish(Event event);
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventServiceConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventServiceConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.event;
+
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.hook.EventHookProvider;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import javax.sql.DataSource;
+
+/**
+ * Selects the active {@link EventService} implementation.
+ *
+ * <p>When {@code nifi.registry.cluster.enabled=false} (the default), a
+ * {@link StandardEventService} is created which delivers events in-process via
+ * an in-memory queue.
+ *
+ * <p>When {@code nifi.registry.cluster.enabled=true}, a
+ * {@link ClusterAwareEventService} is created which persists events to the
+ * database and delivers them exactly once from the leader node.
+ */
+@Configuration
+public class EventServiceConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventServiceConfiguration.class);
+
+    @Bean
+    public EventService eventService(
+            final List<EventHookProvider> eventHookProviders,
+            final NiFiRegistryProperties properties,
+            final DataSource dataSource,
+            final LeaderElectionManager leaderElectionManager) {
+
+        if (properties.isClusterEnabled()) {
+            LOGGER.info("Cluster mode is enabled; creating ClusterAwareEventService.");
+            return new ClusterAwareEventService(eventHookProviders, dataSource, leaderElectionManager);
+        }
+
+        LOGGER.info("Cluster mode is disabled; creating StandardEventService.");
+        return new StandardEventService(eventHookProviders);
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/StandardEventService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/StandardEventService.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.event;
+
+import org.apache.nifi.registry.hook.Event;
+import org.apache.nifi.registry.hook.EventHookProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Standalone (single-node) implementation of {@link EventService}.
+ *
+ * <p>Events are placed on an in-memory {@link BlockingQueue} and consumed by a
+ * single background thread that delivers them to every configured
+ * {@link EventHookProvider}.
+ *
+ * <p>This implementation is selected when {@code nifi.registry.cluster.enabled}
+ * is {@code false} (the default). It is instantiated by
+ * {@link EventServiceConfiguration}.
+ */
+public class StandardEventService implements EventService, DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StandardEventService.class);
+
+    // Generous capacity so the in-memory queue never blocks normal operations.
+    static final int EVENT_QUEUE_SIZE = 10_000;
+
+    private final BlockingQueue<Event> eventQueue;
+    private final ExecutorService consumerExecutor;
+    private final List<EventHookProvider> eventHookProviders;
+
+    public StandardEventService(final List<EventHookProvider> eventHookProviders) {
+        this.eventQueue = new LinkedBlockingQueue<>(EVENT_QUEUE_SIZE);
+        this.consumerExecutor = Executors.newSingleThreadExecutor(r -> {
+            final Thread t = new Thread(r, "EventConsumer");
+            t.setDaemon(true);
+            return t;
+        });
+        this.eventHookProviders = new ArrayList<>(eventHookProviders);
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        LOGGER.info("Starting StandardEventService event consumer.");
+
+        consumerExecutor.execute(() -> {
+            while (!Thread.interrupted()) {
+                try {
+                    final Event event = eventQueue.poll(1000, TimeUnit.MILLISECONDS);
+                    if (event == null) {
+                        continue;
+                    }
+                    deliverToProviders(event);
+                } catch (final InterruptedException e) {
+                    LOGGER.warn("StandardEventService consumer interrupted.");
+                    return;
+                }
+            }
+        });
+
+        LOGGER.info("StandardEventService event consumer started.");
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("Shutting down StandardEventService event consumer.");
+        consumerExecutor.shutdownNow();
+    }
+
+    @Override
+    public void publish(final Event event) {
+        if (event == null) {
+            return;
+        }
+
+        try {
+            event.validate();
+            final boolean queued = eventQueue.offer(event);
+            if (!queued) {
+                LOGGER.error("Unable to queue event because queue is full");
+            }
+        } catch (final IllegalStateException e) {
+            LOGGER.error("Invalid event: {}", e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private void deliverToProviders(final Event event) {
+        for (final EventHookProvider provider : eventHookProviders) {
+            try {
+                if (event.getEventType() == null || provider.shouldHandle(event.getEventType())) {
+                    provider.handle(event);
+                }
+            } catch (final Exception e) {
+                LOGGER.error("Error handling event hook", e);
+            }
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionManager.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.registry.extension;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
 import org.apache.nifi.registry.hook.EventHookProvider;
 import org.apache.nifi.registry.security.authentication.IdentityProvider;
 import org.apache.nifi.registry.security.authorization.AccessPolicyProvider;
@@ -65,14 +66,26 @@ public class ExtensionManager {
     private final Map<String, ExtensionClassLoader> classLoaderMap = new HashMap<>();
     private final AtomicBoolean loaded = new AtomicBoolean(false);
 
+    // Optional: injected only when cluster mode is enabled; used for logging.
+    private LeaderElectionManager leaderElectionManager;
+
     @Autowired
     public ExtensionManager(final NiFiRegistryProperties properties) {
         this.properties = properties;
     }
 
+    @Autowired(required = false)
+    public void setLeaderElectionManager(final LeaderElectionManager leaderElectionManager) {
+        this.leaderElectionManager = leaderElectionManager;
+    }
+
     @PostConstruct
     public synchronized void discoverExtensions() {
         if (!loaded.get()) {
+            if (leaderElectionManager != null) {
+                LOGGER.info("Discovering extensions on cluster node (isLeader={}).", leaderElectionManager.isLeader());
+            }
+
             // get the list of class loaders to consider
             final List<ExtensionClassLoader> classLoaders = getClassLoaders();
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java
@@ -51,6 +51,8 @@ import org.apache.nifi.registry.security.authorization.exception.AuthorizationAc
 import org.apache.nifi.registry.security.authorization.exception.UninheritableAuthorizationsException;
 import org.apache.nifi.registry.security.authorization.generated.Authorizers;
 import org.apache.nifi.registry.security.authorization.generated.Prop;
+import org.apache.nifi.registry.security.authorization.database.CacheRefreshPoller;
+import org.apache.nifi.registry.security.authorization.database.CacheInvalidator;
 import org.apache.nifi.registry.security.exception.SecurityProviderCreationException;
 import org.apache.nifi.registry.security.exception.SecurityProviderDestructionException;
 import org.apache.nifi.registry.security.identity.IdentityMapper;
@@ -103,6 +105,8 @@ public class AuthorizerFactory implements UserGroupProviderLookup, AccessPolicyP
     private final RegistryService registryService;
     private final DataSource dataSource;
     private final IdentityMapper identityMapper;
+    private final CacheRefreshPoller cacheRefreshPoller;
+    private final CacheInvalidator cacheInvalidator;
 
     private Authorizer authorizer;
     private final Map<String, UserGroupProvider> userGroupProviders = new HashMap<>();
@@ -115,13 +119,17 @@ public class AuthorizerFactory implements UserGroupProviderLookup, AccessPolicyP
             final ExtensionManager extensionManager,
             final RegistryService registryService,
             final DataSource dataSource,
-            final IdentityMapper identityMapper) {
+            final IdentityMapper identityMapper,
+            final CacheRefreshPoller cacheRefreshPoller,
+            final CacheInvalidator cacheInvalidator) {
 
         this.properties = Objects.requireNonNull(properties);
         this.extensionManager = Objects.requireNonNull(extensionManager);
         this.registryService = Objects.requireNonNull(registryService);
         this.dataSource = Objects.requireNonNull(dataSource);
         this.identityMapper = Objects.requireNonNull(identityMapper);
+        this.cacheRefreshPoller = Objects.requireNonNull(cacheRefreshPoller);
+        this.cacheInvalidator = Objects.requireNonNull(cacheInvalidator);
     }
 
     /***** UserGroupProviderLookup *****/
@@ -444,6 +452,12 @@ public class AuthorizerFactory implements UserGroupProviderLookup, AccessPolicyP
                     } else if (IdentityMapper.class.isAssignableFrom(argumentType)) {
                         // identity mapper injection
                         method.invoke(instance, identityMapper);
+                    } else if (CacheRefreshPoller.class.isAssignableFrom(argumentType)) {
+                        // cache refresh poller injection
+                        method.invoke(instance, cacheRefreshPoller);
+                    } else if (CacheInvalidator.class.isAssignableFrom(argumentType)) {
+                        // cache invalidator injection
+                        method.invoke(instance, cacheInvalidator);
                     }
                 }
             }
@@ -476,6 +490,12 @@ public class AuthorizerFactory implements UserGroupProviderLookup, AccessPolicyP
                     } else if (IdentityMapper.class.isAssignableFrom(fieldType)) {
                         // identity mapper injection
                         field.set(instance, identityMapper);
+                    } else if (CacheRefreshPoller.class.isAssignableFrom(fieldType)) {
+                        // cache refresh poller injection
+                        field.set(instance, cacheRefreshPoller);
+                    } else if (CacheInvalidator.class.isAssignableFrom(fieldType)) {
+                        // cache invalidator injection
+                        field.set(instance, cacheInvalidator);
                     }
                 }
             }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/CacheInvalidator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/CacheInvalidator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.authorization.database;
+
+/**
+ * Abstraction over the mechanism used to signal cache invalidation across
+ * cluster nodes when authorization data changes.
+ *
+ * <p>Two implementations are provided:
+ * <ul>
+ *   <li>{@link DatabaseCacheInvalidator} — increments a row in the
+ *       {@code CACHE_VERSION} table; peers discover the change via
+ *       {@link CacheRefreshPoller} (used when
+ *       {@code nifi.registry.cluster.coordination=database}).</li>
+ *   <li>{@link ZkCacheInvalidator} — updates a ZooKeeper ZNode and uses
+ *       a persistent {@code CuratorCache} watcher to push invalidation to
+ *       all peers immediately (used when
+ *       {@code nifi.registry.cluster.coordination=zookeeper}).</li>
+ * </ul>
+ */
+public interface CacheInvalidator {
+
+    /**
+     * Signals to all other cluster nodes that the cache for {@code domain}
+     * is stale and must be reloaded.  Called after every write to the
+     * corresponding authorization store.
+     *
+     * @param domain one of {@link CacheRefreshPoller#DOMAIN_ACCESS_POLICIES}
+     *               or {@link CacheRefreshPoller#DOMAIN_USER_GROUPS}
+     */
+    void notifyChanged(String domain);
+
+    /**
+     * Registers a callback that is invoked whenever another cluster node
+     * signals a cache change for {@code domain}.
+     *
+     * <p>For the database implementation this is a no-op because
+     * {@link CacheRefreshPoller} drives refreshes directly.  For the
+     * ZooKeeper implementation a {@code CuratorCache} watcher is set up
+     * here so that refreshes are push-based.
+     *
+     * @param domain     the cache domain to watch
+     * @param onChanged  callback invoked on the watcher thread when a change is detected
+     */
+    void watchDomain(String domain, Runnable onChanged);
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/CacheInvalidatorConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/CacheInvalidatorConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.authorization.database;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * Selects the active {@link CacheInvalidator} implementation based on
+ * {@code nifi.registry.cluster.coordination}.
+ *
+ * <ul>
+ *   <li>{@code database} (default) — {@link DatabaseCacheInvalidator}:
+ *       increments {@code CACHE_VERSION} rows; peers poll via
+ *       {@link CacheRefreshPoller}.</li>
+ *   <li>{@code zookeeper} — {@link ZkCacheInvalidator}: updates ZNodes;
+ *       peers receive immediate push notifications via {@code CuratorCache}
+ *       watchers.</li>
+ * </ul>
+ */
+@Configuration
+public class CacheInvalidatorConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheInvalidatorConfiguration.class);
+
+    @Bean
+    public CacheInvalidator cacheInvalidator(
+            final NiFiRegistryProperties properties,
+            final DataSource dataSource,
+            final ObjectProvider<CuratorFramework> curatorProvider) {
+
+        if (properties.isClusterEnabled() && properties.isZooKeeperCoordination()) {
+            LOGGER.info("Cluster coordination=zookeeper; creating ZkCacheInvalidator.");
+            return new ZkCacheInvalidator(curatorProvider.getObject(), properties);
+        }
+
+        LOGGER.info("Cluster coordination=database; creating DatabaseCacheInvalidator.");
+        return new DatabaseCacheInvalidator(dataSource);
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/CacheRefreshPoller.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/CacheRefreshPoller.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.authorization.database;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.sql.DataSource;
+
+/**
+ * Background component that polls the {@code CACHE_VERSION} table and triggers
+ * in-memory cache reloads on {@link DatabaseAccessPolicyProvider} and
+ * {@link DatabaseUserGroupProvider} when another cluster node has made changes.
+ *
+ * <p>Only active when {@code nifi.registry.cluster.enabled=true} in
+ * {@code nifi-registry.properties}. The poll interval defaults to 15 s and is
+ * configurable via {@code nifi.registry.cluster.cache.refresh.interval.ms}.
+ *
+ * <p>Provider instances register themselves by calling
+ * {@link #setAccessPolicyProvider} / {@link #setUserGroupProvider} on the
+ * poller instance, which is injected into each provider via the
+ * {@code @AuthorizerContext} mechanism during provider initialisation.
+ */
+@Component
+public class CacheRefreshPoller implements DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheRefreshPoller.class);
+
+    static final String DOMAIN_ACCESS_POLICIES = "ACCESS_POLICIES";
+    static final String DOMAIN_USER_GROUPS = "USER_GROUPS";
+
+    // Provider instances are not Spring beans; they register themselves on initialisation
+    // via the CacheRefreshPoller instance injected through @AuthorizerContext.
+    private DatabaseAccessPolicyProvider accessPolicyProvider;
+    private DatabaseUserGroupProvider userGroupProvider;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final NiFiRegistryProperties properties;
+    private final ScheduledExecutorService scheduler;
+
+    // -1 means "first poll — record version but do not refresh"
+    private final AtomicLong lastAccessPoliciesVersion = new AtomicLong(-1);
+    private final AtomicLong lastUserGroupsVersion = new AtomicLong(-1);
+
+    @Autowired
+    public CacheRefreshPoller(final DataSource dataSource, final NiFiRegistryProperties properties) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.properties = properties;
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread t = new Thread(r, "CacheRefreshPoller");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @PostConstruct
+    public void start() {
+        if (!properties.isClusterEnabled()) {
+            LOGGER.info("Cluster mode is disabled; CacheRefreshPoller will not start.");
+            return;
+        }
+
+        if (properties.isZooKeeperCoordination()) {
+            LOGGER.info("Cluster coordination=zookeeper; CacheRefreshPoller is replaced by ZkCacheInvalidator watches.");
+            return;
+        }
+
+        final long intervalMs = properties.getClusterCacheRefreshIntervalMs();
+        LOGGER.info("Starting CacheRefreshPoller with interval {} ms.", intervalMs);
+        scheduler.scheduleWithFixedDelay(this::pollAndRefresh, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("Shutting down CacheRefreshPoller.");
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * Called by {@link DatabaseAccessPolicyProvider} during initialisation so the
+     * poller can trigger a cache reload on that provider when the version changes.
+     */
+    void setAccessPolicyProvider(final DatabaseAccessPolicyProvider provider) {
+        accessPolicyProvider = provider;
+    }
+
+    /**
+     * Called by {@link DatabaseUserGroupProvider} during initialisation so the
+     * poller can trigger a cache reload on that provider when the version changes.
+     */
+    void setUserGroupProvider(final DatabaseUserGroupProvider provider) {
+        userGroupProvider = provider;
+    }
+
+    private void pollAndRefresh() {
+        try {
+            checkDomainAndRefreshIfNeeded(
+                    DOMAIN_ACCESS_POLICIES,
+                    lastAccessPoliciesVersion,
+                    accessPolicyProvider);
+            checkDomainAndRefreshIfNeeded(
+                    DOMAIN_USER_GROUPS,
+                    lastUserGroupsVersion,
+                    userGroupProvider);
+        } catch (final Exception e) {
+            LOGGER.error("Unexpected error during cache version poll", e);
+        }
+    }
+
+    private void checkDomainAndRefreshIfNeeded(final String domain,
+            final AtomicLong lastKnown,
+            final Object provider) {
+        try {
+            final Long currentVersion = jdbcTemplate.queryForObject(
+                    "SELECT VERSION FROM CACHE_VERSION WHERE CACHE_DOMAIN = ?",
+                    Long.class, domain);
+
+            if (currentVersion == null) {
+                // Table exists but domain not seeded yet — non-cluster or mid-migration; skip.
+                return;
+            }
+
+            final long prev = lastKnown.get();
+            if (prev == -1L) {
+                // First poll: record baseline version without triggering a refresh
+                // (this node's provider already loaded the current data at startup).
+                lastKnown.set(currentVersion);
+                LOGGER.debug("CacheRefreshPoller baseline for domain {}: version={}", domain, currentVersion);
+                return;
+            }
+
+            if (currentVersion > prev) {
+                LOGGER.debug("Cache version changed for domain {} ({} → {}); refreshing.",
+                        domain, prev, currentVersion);
+                runRefresh(domain, provider);
+                lastKnown.set(currentVersion);
+            }
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to read CACHE_VERSION for domain {}: {}", domain, e.getMessage());
+        }
+    }
+
+    private void runRefresh(final String domain, final Object provider) {
+        if (DOMAIN_ACCESS_POLICIES.equals(domain) && provider instanceof DatabaseAccessPolicyProvider p) {
+            p.refreshAccessPolicyHolder();
+        } else if (DOMAIN_USER_GROUPS.equals(domain) && provider instanceof DatabaseUserGroupProvider p) {
+            p.refreshUserGroupHolder();
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseAccessPolicyProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseAccessPolicyProvider.java
@@ -61,6 +61,8 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
 
     private DataSource dataSource;
     private IdentityMapper identityMapper;
+    private CacheRefreshPoller cacheRefreshPoller;
+    private CacheInvalidator cacheInvalidator;
 
     private JdbcTemplate jdbcTemplate;
 
@@ -76,10 +78,28 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         this.identityMapper = identityMapper;
     }
 
+    @AuthorizerContext
+    public void setCacheRefreshPoller(final CacheRefreshPoller cacheRefreshPoller) {
+        this.cacheRefreshPoller = cacheRefreshPoller;
+    }
+
+    @AuthorizerContext
+    public void setCacheInvalidator(final CacheInvalidator cacheInvalidator) {
+        this.cacheInvalidator = cacheInvalidator;
+    }
+
     @Override
     protected void doInitialize(AccessPolicyProviderInitializationContext initializationContext) throws SecurityProviderCreationException {
         super.doInitialize(initializationContext);
         this.jdbcTemplate = new JdbcTemplate(dataSource);
+        // Database mode: register with the poller so it can trigger refreshes on version change.
+        if (cacheRefreshPoller != null) {
+            cacheRefreshPoller.setAccessPolicyProvider(this);
+        }
+        // ZooKeeper mode: set up a persistent watch so cache is refreshed on remote writes.
+        if (cacheInvalidator != null) {
+            cacheInvalidator.watchDomain(CacheRefreshPoller.DOMAIN_ACCESS_POLICIES, this::refreshAccessPolicyHolder);
+        }
     }
 
     @Override
@@ -174,6 +194,7 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         createPolicyUserAndGroups(accessPolicy);
 
         refreshAccessPolicyHolder();
+        bumpCacheVersion();
 
         return accessPolicy;
     }
@@ -201,6 +222,7 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         createPolicyUserAndGroups(accessPolicy);
 
         refreshAccessPolicyHolder();
+        bumpCacheVersion();
 
         return accessPolicy;
     }
@@ -271,6 +293,7 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         }
 
         refreshAccessPolicyHolder();
+        bumpCacheVersion();
 
         return accessPolicy;
     }
@@ -293,12 +316,14 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         final String policyGroupSql = "INSERT INTO APP_POLICY_GROUP(POLICY_IDENTIFIER, GROUP_IDENTIFIER) VALUES (?, ?)";
         jdbcTemplate.update(policyGroupSql, policyIdentifier, groupIdentifier);
         refreshAccessPolicyHolder();
+        bumpCacheVersion();
     }
 
     protected void insertPolicyUser(final String policyIdentifier, final String userIdentifier) {
         final String policyUserSql = "INSERT INTO APP_POLICY_USER(POLICY_IDENTIFIER, USER_IDENTIFIER) VALUES (?, ?)";
         jdbcTemplate.update(policyUserSql, policyIdentifier, userIdentifier);
         refreshAccessPolicyHolder();
+        bumpCacheVersion();
     }
 
     protected DatabaseAccessPolicy getDatabaseAcessPolicy(final String policyIdentifier) {
@@ -366,9 +391,15 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         }
     }
 
-    private synchronized void refreshAccessPolicyHolder() {
+    synchronized void refreshAccessPolicyHolder() {
         final Set<AccessPolicy> allPolicies = getDatabaseAccessPolicies();
         this.accessPoliciesHolder.set(new DatabaseAccessPolicyHolder(allPolicies));
+    }
+
+    private void bumpCacheVersion() {
+        if (cacheInvalidator != null) {
+            cacheInvalidator.notifyChanged(CacheRefreshPoller.DOMAIN_ACCESS_POLICIES);
+        }
     }
 
     //-- util methods

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseCacheInvalidator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseCacheInvalidator.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.authorization.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * {@link CacheInvalidator} backed by the {@code CACHE_VERSION} database table.
+ *
+ * <p>{@link #notifyChanged} increments the version counter for the given
+ * domain.  Other nodes discover the change through the {@link CacheRefreshPoller}
+ * polling loop, so {@link #watchDomain} is a no-op here.
+ *
+ * <p>Used when {@code nifi.registry.cluster.coordination=database} (the default).
+ */
+public class DatabaseCacheInvalidator implements CacheInvalidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseCacheInvalidator.class);
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DatabaseCacheInvalidator(final DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Override
+    public void notifyChanged(final String domain) {
+        try {
+            jdbcTemplate.update(
+                    "UPDATE CACHE_VERSION SET VERSION = VERSION + 1 WHERE CACHE_DOMAIN = ?",
+                    domain);
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to bump CACHE_VERSION for domain {}: {}", domain, e.getMessage());
+        }
+    }
+
+    /**
+     * No-op: {@link CacheRefreshPoller} drives cache refreshes directly in
+     * database-coordination mode.
+     */
+    @Override
+    public void watchDomain(final String domain, final Runnable onChanged) {
+        // intentionally empty — polling handled by CacheRefreshPoller
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
@@ -59,6 +59,8 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
 
     private DataSource dataSource;
     private IdentityMapper identityMapper;
+    private CacheRefreshPoller cacheRefreshPoller;
+    private CacheInvalidator cacheInvalidator;
 
     private JdbcTemplate jdbcTemplate;
 
@@ -74,9 +76,27 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         this.identityMapper = identityMapper;
     }
 
+    @AuthorizerContext
+    public void setCacheRefreshPoller(final CacheRefreshPoller cacheRefreshPoller) {
+        this.cacheRefreshPoller = cacheRefreshPoller;
+    }
+
+    @AuthorizerContext
+    public void setCacheInvalidator(final CacheInvalidator cacheInvalidator) {
+        this.cacheInvalidator = cacheInvalidator;
+    }
+
     @Override
     public void initialize(final UserGroupProviderInitializationContext initializationContext) throws SecurityProviderCreationException {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
+        // Database mode: register with the poller so it can trigger refreshes on version change.
+        if (cacheRefreshPoller != null) {
+            cacheRefreshPoller.setUserGroupProvider(this);
+        }
+        // ZooKeeper mode: set up a persistent watch so cache is refreshed on remote writes.
+        if (cacheInvalidator != null) {
+            cacheInvalidator.watchDomain(CacheRefreshPoller.DOMAIN_USER_GROUPS, this::refreshUserGroupHolder);
+        }
     }
 
     @Override
@@ -131,6 +151,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         jdbcTemplate.update(sql, user.getIdentifier(), user.getIdentity());
 
         refreshUserGroupHolder();
+        bumpCacheVersion();
 
         return user;
     }
@@ -149,6 +170,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         }
 
         refreshUserGroupHolder();
+        bumpCacheVersion();
 
         return user;
     }
@@ -215,6 +237,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         }
 
         refreshUserGroupHolder();
+        bumpCacheVersion();
 
         return user;
     }
@@ -240,6 +263,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         createUserGroups(group);
 
         refreshUserGroupHolder();
+        bumpCacheVersion();
 
         return group;
     }
@@ -265,6 +289,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         createUserGroups(group);
 
         refreshUserGroupHolder();
+        bumpCacheVersion();
 
         return group;
     }
@@ -314,6 +339,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
         }
 
         refreshUserGroupHolder();
+        bumpCacheVersion();
 
         return group;
     }
@@ -335,10 +361,16 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
                 .build();
     }
 
-    private synchronized void refreshUserGroupHolder() {
+    synchronized void refreshUserGroupHolder() {
         final Set<User> allUsers = getDatabaseUsers();
         final Set<Group> allGroups = getDatabaseGroups();
         this.userGroupHolder.set(new DatabaseUserGroupHolder(allUsers, allGroups));
+    }
+
+    private void bumpCacheVersion() {
+        if (cacheInvalidator != null) {
+            cacheInvalidator.notifyChanged(CacheRefreshPoller.DOMAIN_USER_GROUPS);
+        }
     }
 
     //-- util methods

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/ZkCacheInvalidator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/ZkCacheInvalidator.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.authorization.database;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link CacheInvalidator} backed by ZooKeeper ZNode watches.
+ *
+ * <p>Each cache domain maps to a persistent ZNode under
+ * {@code <rootNode>/cache-version/<domain>}.
+ *
+ * <ul>
+ *   <li>{@link #notifyChanged} calls {@code setData()} on the domain ZNode,
+ *       which causes ZooKeeper to fire a {@code NodeDataChanged} event on all
+ *       cluster nodes that are watching — including the current node.</li>
+ *   <li>{@link #watchDomain} sets up a {@link CuratorCache} (Curator 5.x
+ *       persistent-watcher replacement for {@code NodeCache}) that invokes
+ *       the supplied {@code onChanged} callback whenever the ZNode is created
+ *       or updated.</li>
+ * </ul>
+ *
+ * <p>Used when {@code nifi.registry.cluster.coordination=zookeeper}.
+ */
+public class ZkCacheInvalidator implements CacheInvalidator, DisposableBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZkCacheInvalidator.class);
+
+    private final CuratorFramework client;
+    private final String rootNode;
+    private final List<CuratorCache> caches = new ArrayList<>();
+
+    public ZkCacheInvalidator(final CuratorFramework client, final NiFiRegistryProperties properties) {
+        this.client = client;
+        final String root = properties.getZooKeeperRootNode();
+        this.rootNode = root.endsWith("/") ? root.substring(0, root.length() - 1) : root;
+    }
+
+    @Override
+    public void notifyChanged(final String domain) {
+        final String path = domainPath(domain);
+        try {
+            client.setData().forPath(path, new byte[0]);
+            LOGGER.debug("Bumped ZK cache-version node for domain '{}'.", domain);
+        } catch (final KeeperException.NoNodeException nne) {
+            // Node doesn't exist yet — create it (first write after a fresh cluster start)
+            try {
+                client.create().creatingParentsIfNeeded().forPath(path, new byte[0]);
+                LOGGER.debug("Created ZK cache-version node for domain '{}'.", domain);
+            } catch (final KeeperException.NodeExistsException nee) {
+                // Lost a creation race with another node — retry setData
+                try {
+                    client.setData().forPath(path, new byte[0]);
+                } catch (final Exception e) {
+                    LOGGER.warn("Failed to notify ZK cache change for domain '{}': {}", domain, e.getMessage());
+                }
+            } catch (final Exception e) {
+                LOGGER.warn("Failed to create ZK cache-version node for domain '{}': {}", domain, e.getMessage());
+            }
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to notify ZK cache change for domain '{}': {}", domain, e.getMessage());
+        }
+    }
+
+    @Override
+    public void watchDomain(final String domain, final Runnable onChanged) {
+        final String path = domainPath(domain);
+
+        final CuratorCache cache = CuratorCache.build(client, path);
+        cache.listenable().addListener((type, oldData, newData) -> {
+            if (type == CuratorCacheListener.Type.NODE_CHANGED
+                    || type == CuratorCacheListener.Type.NODE_CREATED) {
+                LOGGER.debug("ZK cache-version changed for domain '{}' ({}); triggering refresh.", domain, type);
+                try {
+                    onChanged.run();
+                } catch (final Exception e) {
+                    LOGGER.error("Error running cache refresh callback for domain '{}'", domain, e);
+                }
+            }
+        });
+
+        cache.start();
+        caches.add(cache);
+        LOGGER.info("Watching ZK cache-version node '{}' for domain '{}'.", path, domain);
+    }
+
+    @Override
+    public void destroy() {
+        for (final CuratorCache cache : caches) {
+            try {
+                cache.close();
+            } catch (final Exception e) {
+                LOGGER.debug("Exception closing CuratorCache", e);
+            }
+        }
+        caches.clear();
+    }
+
+    private String domainPath(final String domain) {
+        return rootNode + "/cache-version/" + domain;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/resources/db/migration/default/V9__AddClusterTables.sql
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/resources/db/migration/default/V9__AddClusterTables.sql
@@ -1,0 +1,55 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Cache version table: one row per authorization domain, incremented on every write by any cluster node.
+-- Nodes poll this table to detect out-of-date in-memory caches and trigger a reload.
+
+CREATE TABLE CACHE_VERSION (
+    CACHE_DOMAIN VARCHAR(50) NOT NULL,
+    VERSION      BIGINT      NOT NULL DEFAULT 0,
+    CONSTRAINT PK__CACHE_VERSION PRIMARY KEY (CACHE_DOMAIN)
+);
+
+-- Distributed leader-election lock table.
+-- Only one row exists (LOCK_KEY = 'LEADER'). The node that holds the lease
+-- before EXPIRES_AT is the cluster leader.
+CREATE TABLE CLUSTER_LEADER (
+                                LOCK_KEY   VARCHAR(50)  NOT NULL,
+                                NODE_ID    VARCHAR(100) NOT NULL,
+                                EXPIRES_AT TIMESTAMP    NOT NULL,
+                                CONSTRAINT PK__CLUSTER_LEADER PRIMARY KEY (LOCK_KEY)
+);
+
+-- Durable event log for cluster-wide hook delivery.
+-- Any node can INSERT an event row; the leader node delivers it to
+-- EventHookProviders and marks PROCESSED = TRUE.
+-- Retention: processed rows older than 7 days are deleted by the leader.
+CREATE TABLE REGISTRY_EVENT (
+                                EVENT_ID   VARCHAR(50)  NOT NULL,
+                                EVENT_TYPE VARCHAR(100) NOT NULL,
+                                EVENT_DATA TEXT         NOT NULL,
+                                CREATED_AT TIMESTAMP    NOT NULL,
+                                PROCESSED  BOOLEAN      NOT NULL DEFAULT FALSE,
+                                CONSTRAINT PK__REGISTRY_EVENT PRIMARY KEY (EVENT_ID)
+);
+
+-- Track how many delivery attempts have been made for each event.
+-- When RETRY_COUNT reaches the application-level maximum the leader logs
+-- a diagnostic WARN and marks the event PROCESSED so it stops blocking delivery.
+ALTER TABLE REGISTRY_EVENT ADD COLUMN RETRY_COUNT INTEGER NOT NULL DEFAULT 0;
+
+INSERT INTO CACHE_VERSION (CACHE_DOMAIN, VERSION) VALUES ('ACCESS_POLICIES', 0);
+INSERT INTO CACHE_VERSION (CACHE_DOMAIN, VERSION) VALUES ('USER_GROUPS', 0);
+

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/resources/db/migration/mysql/V9__AddClusterTables.sql
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/resources/db/migration/mysql/V9__AddClusterTables.sql
@@ -1,0 +1,55 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Cache version table: one row per authorization domain, incremented on every write by any cluster node.
+-- Nodes poll this table to detect out-of-date in-memory caches and trigger a reload.
+
+CREATE TABLE CACHE_VERSION (
+    CACHE_DOMAIN VARCHAR(50) NOT NULL,
+    VERSION      BIGINT      NOT NULL DEFAULT 0,
+    CONSTRAINT PK__CACHE_VERSION PRIMARY KEY (CACHE_DOMAIN)
+);
+
+-- Only one row exists (LOCK_KEY = 'LEADER'). The node that holds the lease
+-- before EXPIRES_AT is the cluster leader.
+CREATE TABLE CLUSTER_LEADER (
+                                LOCK_KEY   VARCHAR(50)  NOT NULL,
+                                NODE_ID    VARCHAR(100) NOT NULL,
+                                EXPIRES_AT TIMESTAMP    NOT NULL,
+                                CONSTRAINT PK__CLUSTER_LEADER PRIMARY KEY (LOCK_KEY)
+);
+
+-- Durable event log for cluster-wide hook delivery.
+-- Any node can INSERT an event row; the leader node delivers it to
+-- EventHookProviders and marks PROCESSED = TRUE.
+-- Retention: processed rows older than 7 days are deleted by the leader.
+CREATE TABLE REGISTRY_EVENT (
+                                EVENT_ID   VARCHAR(50)  NOT NULL,
+                                EVENT_TYPE VARCHAR(100) NOT NULL,
+                                EVENT_DATA TEXT         NOT NULL,
+                                CREATED_AT TIMESTAMP    NOT NULL,
+                                PROCESSED  BOOLEAN      NOT NULL DEFAULT FALSE,
+                                CONSTRAINT PK__REGISTRY_EVENT PRIMARY KEY (EVENT_ID)
+);
+
+-- Track how many delivery attempts have been made for each event.
+-- When RETRY_COUNT reaches the application-level maximum the leader logs
+-- a diagnostic WARN and marks the event PROCESSED so it stops blocking delivery.
+ALTER TABLE REGISTRY_EVENT ADD COLUMN RETRY_COUNT INTEGER NOT NULL DEFAULT 0;
+
+
+INSERT INTO CACHE_VERSION (CACHE_DOMAIN, VERSION) VALUES ('ACCESS_POLICIES', 0);
+INSERT INTO CACHE_VERSION (CACHE_DOMAIN, VERSION) VALUES ('USER_GROUPS', 0);
+

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/resources/db/migration/postgres/V9__AddClusterTables.sql
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/resources/db/migration/postgres/V9__AddClusterTables.sql
@@ -1,0 +1,54 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Cache version table: one row per authorization domain, incremented on every write by any cluster node.
+-- Nodes poll this table to detect out-of-date in-memory caches and trigger a reload.
+
+CREATE TABLE CACHE_VERSION (
+    CACHE_DOMAIN VARCHAR(50) NOT NULL,
+    VERSION      BIGINT      NOT NULL DEFAULT 0,
+    CONSTRAINT PK__CACHE_VERSION PRIMARY KEY (CACHE_DOMAIN)
+);
+
+-- Distributed leader-election lock table.
+-- Only one row exists (LOCK_KEY = 'LEADER'). The node that holds the lease
+-- before EXPIRES_AT is the cluster leader.
+CREATE TABLE CLUSTER_LEADER (
+                                LOCK_KEY   VARCHAR(50)  NOT NULL,
+                                NODE_ID    VARCHAR(100) NOT NULL,
+                                EXPIRES_AT TIMESTAMP    NOT NULL,
+                                CONSTRAINT PK__CLUSTER_LEADER PRIMARY KEY (LOCK_KEY)
+);
+
+-- Durable event log for cluster-wide hook delivery.
+-- Any node can INSERT an event row; the leader node delivers it to
+-- EventHookProviders and marks PROCESSED = TRUE.
+-- Retention: processed rows older than 7 days are deleted by the leader.
+CREATE TABLE REGISTRY_EVENT (
+                                EVENT_ID   VARCHAR(50)  NOT NULL,
+                                EVENT_TYPE VARCHAR(100) NOT NULL,
+                                EVENT_DATA TEXT         NOT NULL,
+                                CREATED_AT TIMESTAMP    NOT NULL,
+                                PROCESSED  BOOLEAN      NOT NULL DEFAULT FALSE,
+                                CONSTRAINT PK__REGISTRY_EVENT PRIMARY KEY (EVENT_ID)
+);
+
+-- Track how many delivery attempts have been made for each event.
+-- When RETRY_COUNT reaches the application-level maximum the leader logs
+-- a diagnostic WARN and marks the event PROCESSED so it stops blocking delivery.
+ALTER TABLE REGISTRY_EVENT ADD COLUMN RETRY_COUNT INTEGER NOT NULL DEFAULT 0;
+
+INSERT INTO CACHE_VERSION (CACHE_DOMAIN, VERSION) VALUES ('ACCESS_POLICIES', 0);
+INSERT INTO CACHE_VERSION (CACHE_DOMAIN, VERSION) VALUES ('USER_GROUPS', 0);

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/cluster/TestDatabaseLeaderElectionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/cluster/TestDatabaseLeaderElectionManager.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.cluster;
+
+import org.apache.nifi.registry.db.DatabaseBaseTest;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for {@link DatabaseLeaderElectionManager} using the
+ * in-memory H2 database wired up by {@link DatabaseBaseTest}.
+ *
+ * <p>All tests call {@link DatabaseLeaderElectionManager#tryAcquireOrRenew()}
+ * directly (package-private, same package) to avoid spawning the background
+ * scheduler and to keep tests fast and deterministic.
+ */
+public class TestDatabaseLeaderElectionManager extends DatabaseBaseTest {
+
+    private static final String TEST_NODE_ID = "test-node";
+    private static final String OTHER_NODE_ID = "other-node";
+    private static final String LOCK_KEY = "LEADER";
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private NiFiRegistryProperties properties;
+
+    private JdbcTemplate jdbcTemplate;
+    private DatabaseLeaderElectionManager manager;
+
+    @BeforeEach
+    public void setup() {
+        jdbcTemplate = new JdbcTemplate(dataSource);
+
+        // Ensure the CLUSTER_LEADER table is empty before each test.
+        jdbcTemplate.update("DELETE FROM CLUSTER_LEADER");
+
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.getClusterNodeIdentifier()).thenReturn(TEST_NODE_ID);
+
+        manager = new DatabaseLeaderElectionManager(dataSource, properties);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the CLUSTER_LEADER table is empty the first call to
+     * tryAcquireOrRenew() should INSERT a row and return true.
+     */
+    @Test
+    public void testFirstNodeBecomesLeader() {
+        final boolean result = manager.tryAcquireOrRenew();
+
+        // tryAcquireOrRenew() returns true when the node acquires the lease.
+        // isLeader() reflects the AtomicBoolean updated by heartbeat(), not by
+        // tryAcquireOrRenew() directly, so we verify only the return value here.
+        assertTrue(result, "First node should become leader when no row exists");
+    }
+
+    /**
+     * A node that already holds the lease should successfully renew it on
+     * subsequent calls to tryAcquireOrRenew().
+     */
+    @Test
+    public void testRenewOwnLease() {
+        // Acquire the lease first.
+        assertTrue(manager.tryAcquireOrRenew(), "Initial acquisition should succeed");
+
+        // Renew: the UPDATE ... WHERE NODE_ID = ? branch should match.
+        final boolean renewed = manager.tryAcquireOrRenew();
+
+        assertTrue(renewed, "Node should be able to renew its own active lease");
+    }
+
+    /**
+     * When the CLUSTER_LEADER row exists but its EXPIRES_AT is in the past
+     * our node should claim the expired lease and become the leader.
+     */
+    @Test
+    public void testClaimExpiredLease() {
+        // Insert an expired row owned by a different node.
+        final Timestamp expired = Timestamp.from(Instant.now().minusSeconds(60));
+        jdbcTemplate.update(
+                "INSERT INTO CLUSTER_LEADER (LOCK_KEY, NODE_ID, EXPIRES_AT) VALUES (?, ?, ?)",
+                LOCK_KEY, OTHER_NODE_ID, expired);
+
+        final boolean result = manager.tryAcquireOrRenew();
+
+        assertTrue(result, "Node should claim an expired lease from another node");
+    }
+
+    /**
+     * When the CLUSTER_LEADER row exists and its EXPIRES_AT is in the future
+     * our node should NOT be able to claim it — the active leader still holds it.
+     */
+    @Test
+    public void testDoNotClaimActiveLease() {
+        // Insert an active row owned by a different node.
+        final Timestamp active = Timestamp.from(Instant.now().plusSeconds(60));
+        jdbcTemplate.update(
+                "INSERT INTO CLUSTER_LEADER (LOCK_KEY, NODE_ID, EXPIRES_AT) VALUES (?, ?, ?)",
+                LOCK_KEY, OTHER_NODE_ID, active);
+
+        final boolean result = manager.tryAcquireOrRenew();
+
+        assertFalse(result, "Node must not claim an active lease held by another node");
+    }
+
+    /**
+     * If this node was the leader but another node claims the row (simulating a
+     * lease expiry + takeover), the next heartbeat should detect it is no longer
+     * the leader.
+     *
+     * <p>We simulate the takeover by directly updating the row's NODE_ID to a
+     * different node and extending its EXPIRES_AT, then calling tryAcquireOrRenew()
+     * again.
+     */
+    @Test
+    public void testBecomeFollowerAfterLeadershipLost() {
+        // Acquire the lease.
+        assertTrue(manager.tryAcquireOrRenew());
+
+        // Simulate another node stealing the lease (e.g. our node was paused,
+        // lease expired, other node claimed it, and then extended it further).
+        final Timestamp newExpiry = Timestamp.from(Instant.now().plusSeconds(120));
+        jdbcTemplate.update(
+                "UPDATE CLUSTER_LEADER SET NODE_ID = ?, EXPIRES_AT = ? WHERE LOCK_KEY = ?",
+                OTHER_NODE_ID, newExpiry, LOCK_KEY);
+
+        // Our next heartbeat should fail to renew (row no longer belongs to us)
+        // and fail to claim (row is not expired) => follower.
+        final boolean stillLeader = manager.tryAcquireOrRenew();
+
+        assertFalse(stillLeader, "Node should become a follower after another node claims the lease");
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/db/DatabaseTestApplication.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/db/DatabaseTestApplication.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.registry.db;
 
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
 import org.apache.nifi.registry.properties.NiFiRegistryProperties;
 import org.mockito.Mockito;
 import org.springframework.boot.SpringApplication;
@@ -31,13 +32,18 @@ import org.springframework.context.annotation.FilterType;
  * This class must be in the "db" package in order to find the entities in "db.entity" and repositories in "db.repository".
  *
  * The DataSourceFactory is excluded so that Spring Boot will load an in-memory H2 database.
+ * DataSyncBootstrapper is excluded because it tries to perform ZK-based bootstrap sync on startup,
+ * which is not relevant in the unit-test context.
  */
 @SpringBootApplication
 @ComponentScan(
         excludeFilters = {
                 @ComponentScan.Filter(
                         type = FilterType.ASSIGNABLE_TYPE,
-                        value = DataSourceFactory.class)
+                        value = DataSourceFactory.class),
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        value = DataSyncBootstrapper.class)
         })
 public class DatabaseTestApplication {
 
@@ -48,6 +54,11 @@ public class DatabaseTestApplication {
     @Bean
     public NiFiRegistryProperties createNiFiRegistryProperties() {
         return Mockito.mock(NiFiRegistryProperties.class);
+    }
+
+    @Bean
+    public LeaderElectionManager createLeaderElectionManager() {
+        return Mockito.mock(LeaderElectionManager.class);
     }
 
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/db/TestDataSyncBootstrapper.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/db/TestDataSyncBootstrapper.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.db;
+
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeAddress;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Optional;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure Mockito unit tests for {@link DataSyncBootstrapper}.
+ *
+ * <p>No Spring context is loaded.  All dependencies are mocked so that each
+ * test can push {@link DataSyncBootstrapper#syncFromLeaderIfNeeded()} through
+ * a specific early-exit path and verify that no HTTP sync call is made.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestDataSyncBootstrapper {
+
+    @Mock
+    private NiFiRegistryProperties properties;
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private LeaderElectionManager leaderElectionManager;
+
+    @Mock
+    private NodeRegistry nodeRegistry;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private DatabaseMetaData databaseMetaData;
+
+    @Mock
+    private Statement statement;
+
+    @Mock
+    private ResultSet resultSet;
+
+    // -------------------------------------------------------------------------
+    // Tests — early-exit paths
+    // -------------------------------------------------------------------------
+
+    /**
+     * When cluster is disabled syncFromLeaderIfNeeded() should return
+     * immediately without touching the NodeRegistry or DataSource.
+     */
+    @Test
+    public void testSkipsWhenNotClusterEnabled() {
+        when(properties.isClusterEnabled()).thenReturn(false);
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, nodeRegistry);
+        bootstrapper.syncFromLeaderIfNeeded();
+
+        verify(nodeRegistry, never()).getLeaderAddress();
+    }
+
+    /**
+     * When cluster coordination is "database" (not ZooKeeper)
+     * syncFromLeaderIfNeeded() should skip the bootstrap sync entirely.
+     */
+    @Test
+    public void testSkipsWhenNotZkCoordination() {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.isZooKeeperCoordination()).thenReturn(false);
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, nodeRegistry);
+        bootstrapper.syncFromLeaderIfNeeded();
+
+        verify(nodeRegistry, never()).getLeaderAddress();
+    }
+
+    /**
+     * When nodeRegistry is null (non-ZK mode, no bean injected) the bootstrapper
+     * should skip the sync.
+     */
+    @Test
+    public void testSkipsWhenNodeRegistryNull() throws Exception {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.isZooKeeperCoordination()).thenReturn(true);
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, null /* nodeRegistry */);
+        bootstrapper.syncFromLeaderIfNeeded();
+
+        // No interactions on dataSource because the null nodeRegistry check
+        // fires before any DB access.
+        verify(dataSource, never()).getConnection();
+    }
+
+    /**
+     * When this node is already the elected leader it should skip the sync —
+     * leaders do not pull from themselves.
+     */
+    @Test
+    public void testSkipsWhenIsLeader() throws Exception {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.isZooKeeperCoordination()).thenReturn(true);
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, nodeRegistry);
+        bootstrapper.syncFromLeaderIfNeeded();
+
+        verify(nodeRegistry, never()).getLeaderAddress();
+    }
+
+    /**
+     * When the local database already has data (COUNT > 0 in BUCKET) the
+     * bootstrapper should skip the sync to avoid overwriting existing data.
+     */
+    @Test
+    public void testSkipsWhenDbNotEmpty() throws Exception {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.isZooKeeperCoordination()).thenReturn(true);
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+
+        // Wire up DataSource → Connection → MetaData → "H2" product name.
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn("H2");
+
+        // Wire up Statement → ResultSet → COUNT = 5 (non-empty).
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT COUNT(*) FROM BUCKET")).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getInt(1)).thenReturn(5);
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, nodeRegistry);
+        bootstrapper.syncFromLeaderIfNeeded();
+
+        // If DB is non-empty the bootstrapper returns before calling getLeaderAddress().
+        verify(nodeRegistry, never()).getLeaderAddress();
+    }
+
+    /**
+     * When this node wins the election while waiting for the leader address it
+     * should detect the leadership change on re-check and skip the HTTP sync call.
+     */
+    @Test
+    public void testSkipsWhenLeaderElectedDuringWait() throws Exception {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.isZooKeeperCoordination()).thenReturn(true);
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn("test-token");
+
+        // First call: not leader; second call (re-check after waitForLeader): leader.
+        when(leaderElectionManager.isLeader()).thenReturn(false, true);
+
+        // Wire up DataSource → H2 + empty bucket table.
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn("H2");
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT COUNT(*) FROM BUCKET")).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getInt(1)).thenReturn(0); // empty DB
+
+        // Leader address is available immediately so waitForLeader() returns fast.
+        final NodeAddress leaderAddress = new NodeAddress("leader-node", "http://leader:18080");
+        when(nodeRegistry.getLeaderAddress()).thenReturn(Optional.of(leaderAddress));
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, nodeRegistry);
+        bootstrapper.syncFromLeaderIfNeeded();
+
+        // getLeaderAddress() must have been called — we entered the waitForLeader() path.
+        verify(nodeRegistry).getLeaderAddress();
+        // isLocalDbH2() and isLocalDbEmpty() each call getConnection() — exactly 2 calls.
+        // A 3rd call would indicate applyScript() ran (RUNSCRIPT), which must NOT happen
+        // because the post-wait isLeader() re-check returned true.
+        // We use org.mockito.Mockito.times(2) to assert exactly two getConnection() calls.
+        verify(dataSource, times(2)).getConnection();
+    }
+
+    /**
+     * When no leader is elected within the timeout window the bootstrapper
+     * should log a warning and return gracefully without throwing.
+     */
+    @Test
+    public void testSkipsWhenNoLeaderElectedWithinTimeout() throws Exception {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.isZooKeeperCoordination()).thenReturn(true);
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn("test-token");
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+
+        // Wire up DataSource → H2 + empty bucket table.
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn("H2");
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT COUNT(*) FROM BUCKET")).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getInt(1)).thenReturn(0); // empty DB
+
+        // nodeRegistry never returns a leader address.
+        when(nodeRegistry.getLeaderAddress()).thenReturn(Optional.empty());
+
+        // Override the wait timeout to 1 ms so the test completes quickly.
+        // DataSyncBootstrapper reads LEADER_WAIT_TIMEOUT_MS as a static final;
+        // we accept the full 30s wait would be too long, so instead we verify
+        // that getLeaderAddress() was called at least once and the method
+        // returns without exception.
+        //
+        // For faster test execution we interrupt the thread after a brief moment.
+        final Thread testThread = Thread.currentThread();
+        final Thread interrupter = new Thread(() -> {
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ignored) {
+            }
+            testThread.interrupt();
+        });
+        interrupter.setDaemon(true);
+        interrupter.start();
+
+        final DataSyncBootstrapper bootstrapper = new DataSyncBootstrapper(
+                properties, dataSource, leaderElectionManager, nodeRegistry);
+        // Must not throw even if interrupted or timed out.
+        bootstrapper.syncFromLeaderIfNeeded();
+        // Clear interrupt flag if it was set.
+        Thread.interrupted();
+
+        // getLeaderAddress() must have been called at least once (we entered the wait loop).
+        verify(nodeRegistry).getLeaderAddress();
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/event/TestClusterAwareEventService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/event/TestClusterAwareEventService.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.event;
+
+import org.apache.nifi.registry.bucket.Bucket;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.db.DatabaseTestApplication;
+import org.apache.nifi.registry.hook.Event;
+import org.apache.nifi.registry.hook.EventHookException;
+import org.apache.nifi.registry.hook.EventHookProvider;
+import org.apache.nifi.registry.hook.EventType;
+import org.apache.nifi.registry.provider.ProviderConfigurationContext;
+import org.apache.nifi.registry.provider.ProviderCreationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for {@link ClusterAwareEventService} using the in-memory
+ * H2 database.
+ *
+ * <p>This test class intentionally does NOT extend {@link org.apache.nifi.registry.db.DatabaseBaseTest}
+ * (which is {@code @Transactional}).  {@link ClusterAwareEventService} delivers
+ * events on a background thread; if test data were inserted inside an uncommitted
+ * transaction the delivery thread would not see it.  Instead each test commits
+ * data explicitly and the {@link AfterEach} cleans up.
+ *
+ * <p>Because {@code deliverPendingEvents()} is private, delivery is triggered
+ * via {@link ClusterAwareEventService#onStartLeading()}, which submits the
+ * delivery task to the already-started scheduler immediately.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = DatabaseTestApplication.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class TestClusterAwareEventService {
+
+    @Autowired
+    private DataSource dataSource;
+
+    private JdbcTemplate jdbcTemplate;
+    private LeaderElectionManager leaderElectionManager;
+    private CapturingEventHookProvider hookProvider;
+    private ClusterAwareEventService eventService;
+
+    @BeforeEach
+    public void setup() {
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.update("DELETE FROM REGISTRY_EVENT");
+
+        leaderElectionManager = mock(LeaderElectionManager.class);
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+
+        hookProvider = new CapturingEventHookProvider();
+        eventService = new ClusterAwareEventService(
+                Collections.singletonList(hookProvider),
+                dataSource,
+                leaderElectionManager);
+
+        // Start the delivery scheduler so onStartLeading() can submit tasks.
+        eventService.start();
+    }
+
+    @AfterEach
+    public void teardown() {
+        eventService.destroy();
+        jdbcTemplate.update("DELETE FROM REGISTRY_EVENT");
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * publish() should persist a row in REGISTRY_EVENT with PROCESSED = false.
+     */
+    @Test
+    public void testPublishPersistsEvent() {
+        final Bucket bucket = newBucket("bucket-pub");
+        final Event event = EventFactory.bucketCreated(bucket);
+
+        eventService.publish(event);
+
+        final Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM REGISTRY_EVENT WHERE PROCESSED = FALSE",
+                Integer.class);
+        assertEquals(1, count, "One unprocessed event row should have been inserted");
+    }
+
+    /**
+     * deliverPendingEvents (triggered via onStartLeading) should dispatch the
+     * event to the hook provider and mark the row as PROCESSED = true.
+     */
+    @Test
+    public void testDeliverPendingEventsCallsProvider() throws InterruptedException {
+        // Insert and commit an unprocessed event row so the background thread can see it.
+        insertRawEvent(UUID.randomUUID().toString(), "CREATE_BUCKET", buildMinimalEventJson("CREATE_BUCKET"), 0, false);
+
+        // Set up a latch so we can wait for delivery without a fixed sleep.
+        hookProvider.setExpectedDeliveries(1);
+
+        // onStartLeading() submits delivery immediately to the scheduler thread.
+        eventService.onStartLeading();
+
+        // Wait up to 2 seconds for the delivery to complete.
+        assertTrue(hookProvider.awaitDelivery(2, TimeUnit.SECONDS),
+                "Provider should receive the event within 2 seconds");
+
+        assertEquals(1, hookProvider.getEvents().size(), "Provider should have received one event");
+
+        // Allow the scheduler task to finish writing PROCESSED = true.
+        Thread.sleep(300);
+
+        final Integer unprocessed = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM REGISTRY_EVENT WHERE PROCESSED = FALSE",
+                Integer.class);
+        assertEquals(0, unprocessed, "Event row should be marked PROCESSED after delivery");
+    }
+
+    /**
+     * When RETRY_COUNT already equals MAX_RETRY_COUNT - 1 and the provider
+     * throws, the event should be discarded (PROCESSED = true, RETRY_COUNT incremented).
+     */
+    @Test
+    public void testMaxRetryMarksProcessed() throws InterruptedException {
+        hookProvider.setShouldThrow(true);
+
+        // Insert event already at retry count 2 (one below MAX_RETRY_COUNT = 3).
+        final String eventId = UUID.randomUUID().toString();
+        insertRawEvent(eventId, "CREATE_BUCKET", buildMinimalEventJson("CREATE_BUCKET"), 2, false);
+
+        // Set a latch to detect when delivery is attempted.
+        hookProvider.setExpectedDeliveries(1);
+
+        eventService.onStartLeading();
+
+        // Wait for the throw to be caught (latch counts down in handle() — but since we
+        // throw, we can't use the latch directly).  Use a short fixed sleep instead.
+        Thread.sleep(1500);
+
+        final Integer retryCount = jdbcTemplate.queryForObject(
+                "SELECT RETRY_COUNT FROM REGISTRY_EVENT WHERE EVENT_ID = ?",
+                Integer.class, eventId);
+        assertEquals(3, retryCount, "RETRY_COUNT should be incremented to 3");
+
+        final Boolean processed = jdbcTemplate.queryForObject(
+                "SELECT PROCESSED FROM REGISTRY_EVENT WHERE EVENT_ID = ?",
+                Boolean.class, eventId);
+        assertTrue(processed, "Event should be marked PROCESSED after max retries");
+    }
+
+    /**
+     * When this node is not the leader the delivery task must be a no-op:
+     * the provider should not be called and the event should remain unprocessed.
+     */
+    @Test
+    public void testNonLeaderDoesNotDeliver() throws InterruptedException {
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+
+        insertRawEvent(UUID.randomUUID().toString(), "CREATE_BUCKET", buildMinimalEventJson("CREATE_BUCKET"), 0, false);
+
+        // Trigger delivery — should be a no-op because isLeader() = false.
+        eventService.onStartLeading();
+
+        // Allow time for the task to run.
+        Thread.sleep(500);
+
+        assertEquals(0, hookProvider.getEvents().size(), "Non-leader should not deliver any events");
+
+        final Integer unprocessed = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM REGISTRY_EVENT WHERE PROCESSED = FALSE",
+                Integer.class);
+        assertEquals(1, unprocessed, "Event should still be unprocessed when node is not leader");
+    }
+
+    /**
+     * Processed events older than RETENTION_DAYS should be deleted.
+     * purgeOldEvents() runs at the end of every delivery pass.
+     */
+    @Test
+    public void testPurgeProcessedOldEvents() throws InterruptedException {
+        // Insert an old processed event (8 days ago, beyond the 7-day window).
+        final Timestamp eightDaysAgo = Timestamp.from(
+                Instant.now().minus(8, ChronoUnit.DAYS));
+        final String oldEventId = UUID.randomUUID().toString();
+        jdbcTemplate.update(
+                "INSERT INTO REGISTRY_EVENT (EVENT_ID, EVENT_TYPE, EVENT_DATA, CREATED_AT, PROCESSED, RETRY_COUNT)"
+                        + " VALUES (?, ?, ?, ?, TRUE, 0)",
+                oldEventId, "CREATE_BUCKET", buildMinimalEventJson("CREATE_BUCKET"), eightDaysAgo);
+
+        // Insert a recent processed event that should NOT be purged.
+        final String recentEventId = UUID.randomUUID().toString();
+        jdbcTemplate.update(
+                "INSERT INTO REGISTRY_EVENT (EVENT_ID, EVENT_TYPE, EVENT_DATA, CREATED_AT, PROCESSED, RETRY_COUNT)"
+                        + " VALUES (?, ?, ?, ?, TRUE, 0)",
+                recentEventId, "DELETE_BUCKET", buildMinimalEventJson("DELETE_BUCKET"),
+                Timestamp.from(Instant.now()));
+
+        // Trigger delivery — purge runs at the end of every delivery pass.
+        eventService.onStartLeading();
+
+        // Wait for scheduler task to complete.
+        Thread.sleep(1000);
+
+        final Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM REGISTRY_EVENT WHERE EVENT_ID = ?",
+                Integer.class, oldEventId);
+        assertEquals(0, count, "Old processed event should have been purged");
+
+        final Integer recentCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM REGISTRY_EVENT WHERE EVENT_ID = ?",
+                Integer.class, recentEventId);
+        assertEquals(1, recentCount, "Recent processed event should NOT be purged");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void insertRawEvent(final String eventId, final String eventType,
+            final String eventData, final int retryCount, final boolean processed) {
+        jdbcTemplate.update(
+                "INSERT INTO REGISTRY_EVENT (EVENT_ID, EVENT_TYPE, EVENT_DATA, CREATED_AT, PROCESSED, RETRY_COUNT)"
+                        + " VALUES (?, ?, ?, ?, ?, ?)",
+                eventId, eventType, eventData,
+                Timestamp.from(Instant.now()),
+                processed, retryCount);
+    }
+
+    /**
+     * Builds the minimal JSON payload that ClusterAwareEventService can
+     * deserialize.  Includes all required fields for a CREATE_BUCKET event.
+     */
+    private String buildMinimalEventJson(final String eventTypeName) {
+        return "{\"eventType\":\"" + eventTypeName + "\","
+                + "\"fields\":[{\"name\":\"BUCKET_ID\",\"value\":\"test-bucket-id\"},"
+                + "{\"name\":\"BUCKET_NAME\",\"value\":\"test\"},"
+                + "{\"name\":\"BUCKET_DESCRIPTION\",\"value\":\"\"},"
+                + "{\"name\":\"CREATED_TIMESTAMP\",\"value\":\"0\"},"
+                + "{\"name\":\"ALLOW_PUBLIC_READ\",\"value\":\"\"},"
+                + "{\"name\":\"USER\",\"value\":\"test-user\"}]}";
+    }
+
+    private static Bucket newBucket(final String name) {
+        final Bucket bucket = new Bucket();
+        bucket.setIdentifier(UUID.randomUUID().toString());
+        bucket.setName(name);
+        bucket.setCreatedTimestamp(Instant.now().toEpochMilli());
+        return bucket;
+    }
+
+    // -------------------------------------------------------------------------
+    // CapturingEventHookProvider
+    // -------------------------------------------------------------------------
+
+    /**
+     * Simple {@link EventHookProvider} that captures handled events, optionally
+     * throws on {@link #handle(Event)} to simulate delivery failure, and exposes
+     * a {@link CountDownLatch} so tests can wait for expected deliveries
+     * without brittle fixed-duration sleeps.
+     */
+    private static class CapturingEventHookProvider implements EventHookProvider {
+
+        private final List<Event> events = new ArrayList<>();
+        private volatile boolean shouldThrow = false;
+        private volatile CountDownLatch latch = new CountDownLatch(0);
+
+        @Override
+        public void onConfigured(final ProviderConfigurationContext configurationContext)
+                throws ProviderCreationException {
+            // no-op
+        }
+
+        @Override
+        public boolean shouldHandle(final EventType eventType) {
+            return true;
+        }
+
+        @Override
+        public void handle(final Event event) throws EventHookException {
+            if (shouldThrow) {
+                latch.countDown();
+                throw new EventHookException("Simulated delivery failure");
+            }
+            events.add(event);
+            latch.countDown();
+        }
+
+        /** Configures the latch to count down after {@code n} deliveries. */
+        public void setExpectedDeliveries(final int n) {
+            this.latch = new CountDownLatch(n);
+        }
+
+        /** Blocks until the expected deliveries complete or the timeout elapses. */
+        public boolean awaitDelivery(final long timeout, final TimeUnit unit)
+                throws InterruptedException {
+            return latch.await(timeout, unit);
+        }
+
+        public List<Event> getEvents() {
+            return events;
+        }
+
+        public void setShouldThrow(final boolean shouldThrow) {
+            this.shouldThrow = shouldThrow;
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/event/TestEventService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/event/TestEventService.java
@@ -36,12 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestEventService {
 
     private CapturingEventHook eventHook;
-    private EventService eventService;
+    private StandardEventService eventService;
 
     @BeforeEach
     public void setup() {
         eventHook = new CapturingEventHook();
-        eventService = new EventService(Collections.singletonList(eventHook));
+        eventService = new StandardEventService(Collections.singletonList(eventHook));
         eventService.postConstruct();
     }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
@@ -123,6 +123,43 @@ public class NiFiRegistryProperties extends ApplicationProperties {
     // Revision Management Properties
     public static final String REVISIONS_ENABLED = "nifi.registry.revisions.enabled";
 
+    // Cluster properties
+    public static final String CLUSTER_ENABLED = "nifi.registry.cluster.enabled";
+    public static final String CLUSTER_NODE_IDENTIFIER = "nifi.registry.cluster.node.identifier";
+    public static final String CLUSTER_CACHE_REFRESH_INTERVAL_MS = "nifi.registry.cluster.cache.refresh.interval.ms";
+
+    // Cluster coordination mode: "database" (default) or "zookeeper"
+    public static final String CLUSTER_COORDINATION = "nifi.registry.cluster.coordination";
+
+    // This node's own HTTP base URL used to register in ZooKeeper and for inter-node replication.
+    // Example: https://node1:18443
+    public static final String CLUSTER_NODE_ADDRESS = "nifi.registry.cluster.node.address";
+
+    // Shared secret required in X-Registry-Internal-Auth header for internal cluster endpoints.
+    public static final String CLUSTER_NODE_INTERNAL_AUTH_TOKEN = "nifi.registry.cluster.node.internal.auth.token";
+    public static final String CLUSTER_COORDINATION_DATABASE = "database";
+    public static final String CLUSTER_COORDINATION_ZOOKEEPER = "zookeeper";
+
+    // ZooKeeper properties (used when cluster.coordination=zookeeper)
+    public static final String ZOOKEEPER_CONNECT_STRING = "nifi.registry.zookeeper.connect.string";
+    public static final String ZOOKEEPER_SESSION_TIMEOUT_MS = "nifi.registry.zookeeper.session.timeout.ms";
+    public static final String ZOOKEEPER_CONNECT_TIMEOUT_MS = "nifi.registry.zookeeper.connect.timeout.ms";
+    public static final String ZOOKEEPER_ROOT_NODE = "nifi.registry.zookeeper.root.node";
+
+    // ZooKeeper TLS / mTLS properties
+    public static final String ZOOKEEPER_CLIENT_SECURE = "nifi.registry.zookeeper.client.secure";
+    public static final String ZOOKEEPER_SECURITY_KEYSTORE = "nifi.registry.zookeeper.security.keystore";
+    public static final String ZOOKEEPER_SECURITY_KEYSTORE_TYPE = "nifi.registry.zookeeper.security.keystoreType";
+    public static final String ZOOKEEPER_SECURITY_KEYSTORE_PASSWD = "nifi.registry.zookeeper.security.keystorePasswd";
+    public static final String ZOOKEEPER_SECURITY_TRUSTSTORE = "nifi.registry.zookeeper.security.truststore";
+    public static final String ZOOKEEPER_SECURITY_TRUSTSTORE_TYPE = "nifi.registry.zookeeper.security.truststoreType";
+    public static final String ZOOKEEPER_SECURITY_TRUSTSTORE_PASSWD = "nifi.registry.zookeeper.security.truststorePasswd";
+
+    // ZooKeeper defaults
+    public static final long DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS = 10_000L;
+    public static final long DEFAULT_ZOOKEEPER_CONNECT_TIMEOUT_MS = 5_000L;
+    public static final String DEFAULT_ZOOKEEPER_ROOT_NODE = "/nifi-registry";
+
     // Defaults
     public static final String DEFAULT_WEB_WORKING_DIR = "./work/jetty";
     public static final String DEFAULT_WEB_HTTPS_APPLICATION_PROTOCOLS = "h2 http/1.1";
@@ -136,6 +173,7 @@ public class NiFiRegistryProperties extends ApplicationProperties {
     public static final String DEFAULT_WEB_SHOULD_SEND_SERVER_VERSION = "true";
     public static final String DEFAULT_SECURITY_USER_OIDC_CONNECT_TIMEOUT = "5 secs";
     public static final String DEFAULT_SECURITY_USER_OIDC_READ_TIMEOUT = "5 secs";
+    public static final long DEFAULT_CLUSTER_CACHE_REFRESH_INTERVAL_MS = 15_000L;
 
     public NiFiRegistryProperties() {
         this(Collections.EMPTY_MAP);
@@ -344,6 +382,138 @@ public class NiFiRegistryProperties extends ApplicationProperties {
 
     public boolean areRevisionsEnabled() {
         return Boolean.parseBoolean(getPropertyAsTrimmedString(REVISIONS_ENABLED));
+    }
+
+    public boolean isClusterEnabled() {
+        return Boolean.parseBoolean(getPropertyAsTrimmedString(CLUSTER_ENABLED));
+    }
+
+    public String getClusterNodeIdentifier() {
+        return getPropertyAsTrimmedString(CLUSTER_NODE_IDENTIFIER);
+    }
+
+    public long getClusterCacheRefreshIntervalMs() {
+        final String value = getPropertyAsTrimmedString(CLUSTER_CACHE_REFRESH_INTERVAL_MS);
+        if (StringUtils.isBlank(value)) {
+            return DEFAULT_CLUSTER_CACHE_REFRESH_INTERVAL_MS;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (final NumberFormatException nfe) {
+            throw new IllegalStateException(String.format("%s must be a long integer value.", CLUSTER_CACHE_REFRESH_INTERVAL_MS));
+        }
+    }
+
+    public String getClusterCoordination() {
+        final String value = getPropertyAsTrimmedString(CLUSTER_COORDINATION);
+        return value == null ? CLUSTER_COORDINATION_DATABASE : value;
+    }
+
+    public boolean isZooKeeperCoordination() {
+        return CLUSTER_COORDINATION_ZOOKEEPER.equalsIgnoreCase(getClusterCoordination());
+    }
+
+    public String getZooKeeperConnectString() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_CONNECT_STRING);
+    }
+
+    public long getZooKeeperSessionTimeoutMs() {
+        final String value = getPropertyAsTrimmedString(ZOOKEEPER_SESSION_TIMEOUT_MS);
+        if (StringUtils.isBlank(value)) {
+            return DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (final NumberFormatException nfe) {
+            throw new IllegalStateException(ZOOKEEPER_SESSION_TIMEOUT_MS + " must be a long integer value.");
+        }
+    }
+
+    public long getZooKeeperConnectTimeoutMs() {
+        final String value = getPropertyAsTrimmedString(ZOOKEEPER_CONNECT_TIMEOUT_MS);
+        if (StringUtils.isBlank(value)) {
+            return DEFAULT_ZOOKEEPER_CONNECT_TIMEOUT_MS;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (final NumberFormatException nfe) {
+            throw new IllegalStateException(ZOOKEEPER_CONNECT_TIMEOUT_MS + " must be a long integer value.");
+        }
+    }
+
+    public String getZooKeeperRootNode() {
+        final String value = getPropertyAsTrimmedString(ZOOKEEPER_ROOT_NODE);
+        return value == null ? DEFAULT_ZOOKEEPER_ROOT_NODE : value;
+    }
+
+    public boolean isZooKeeperClientSecure() {
+        return Boolean.parseBoolean(getPropertyAsTrimmedString(ZOOKEEPER_CLIENT_SECURE));
+    }
+
+    public String getZooKeeperSecurityKeystore() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_SECURITY_KEYSTORE);
+    }
+
+    public String getZooKeeperSecurityKeystoreType() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_SECURITY_KEYSTORE_TYPE);
+    }
+
+    public String getZooKeeperSecurityKeystorePasswd() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_SECURITY_KEYSTORE_PASSWD);
+    }
+
+    public String getZooKeeperSecurityTruststore() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_SECURITY_TRUSTSTORE);
+    }
+
+    public String getZooKeeperSecurityTruststoreType() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_SECURITY_TRUSTSTORE_TYPE);
+    }
+
+    public String getZooKeeperSecurityTruststorePasswd() {
+        return getPropertyAsTrimmedString(ZOOKEEPER_SECURITY_TRUSTSTORE_PASSWD);
+    }
+
+    /**
+     * Returns the HTTP base URL this node registers in ZooKeeper for inter-node
+     * write replication (e.g. {@code http://node1:61080}).
+     *
+     * <p>If {@code nifi.registry.cluster.node.address} is explicitly set that
+     * value is used as-is. Otherwise the URL is derived automatically from the
+     * existing {@code nifi.registry.web.http.*} / {@code nifi.registry.web.https.*}
+     * properties — HTTPS takes precedence over HTTP when both are configured.
+     *
+     * <p>This fallback means Ambari operators do not need to configure an extra
+     * property: the per-host HTTP host and port that Ambari already manages are
+     * sufficient.
+     *
+     * @return base URL string, or {@code null} if none can be determined
+     */
+    public String getClusterNodeAddress() {
+        final String explicit = getPropertyAsTrimmedString(CLUSTER_NODE_ADDRESS);
+        if (!StringUtils.isBlank(explicit)) {
+            return explicit;
+        }
+
+        // Prefer HTTPS when the node has TLS configured.
+        final String httpsHost = getProperty(WEB_HTTPS_HOST);
+        final Integer httpsPort = getPropertyAsInteger(WEB_HTTPS_PORT);
+        if (!StringUtils.isBlank(httpsHost) && httpsPort != null && httpsPort > 0) {
+            return "https://" + httpsHost.trim() + ":" + httpsPort;
+        }
+
+        // Fall back to plain HTTP.
+        final String httpHost = getProperty(WEB_HTTP_HOST);
+        final Integer httpPort = getPropertyAsInteger(WEB_HTTP_PORT);
+        if (!StringUtils.isBlank(httpHost) && httpPort != null && httpPort > 0) {
+            return "http://" + httpHost.trim() + ":" + httpPort;
+        }
+
+        return null;
+    }
+
+    public String getClusterNodeInternalAuthToken() {
+        return getPropertyAsTrimmedString(CLUSTER_NODE_INTERNAL_AUTH_TOKEN);
     }
 
     // Helper functions for common ways of interpreting property values

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/nifi-registry.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/nifi-registry.properties
@@ -113,3 +113,53 @@ nifi.registry.security.user.oidc.claim.groups=${nifi.registry.security.user.oidc
 # revision management #
 # This feature should remain disabled until a future NiFi release that supports the revision API changes
 nifi.registry.revisions.enabled=${nifi.registry.revisions.enabled}
+
+# cluster properties #
+# Set to true to enable active-active clustering.
+nifi.registry.cluster.enabled=false
+
+# Optional human-readable identifier for this node (used in log messages and leader-election records).
+# When left blank the hostname is used.
+nifi.registry.cluster.node.identifier=
+
+# Coordination backend: "database" (default) or "zookeeper"
+#   database  - TTL-based leader election and cache coherency via the shared DB (requires PostgreSQL or MySQL)
+#   zookeeper - Apache Curator / ZooKeeper-based leader election (each node may use its own local H2)
+nifi.registry.cluster.coordination=database
+
+# How often each node polls the CACHE_VERSION table when coordination=database.
+# Default: 15000 ms (15 seconds)
+nifi.registry.cluster.cache.refresh.interval.ms=15000
+
+# ZooKeeper properties (required when nifi.registry.cluster.coordination=zookeeper) #
+# Comma-separated host:port list of ZooKeeper servers.
+nifi.registry.zookeeper.connect.string=
+
+# Root ZNode path for all NiFi Registry entries.  Default: /nifi-registry
+nifi.registry.zookeeper.root.node=/nifi-registry
+
+# ZooKeeper session and connection timeouts (ms).
+nifi.registry.zookeeper.session.timeout.ms=10000
+nifi.registry.zookeeper.connect.timeout.ms=5000
+
+# ZooKeeper TLS / mTLS (optional, requires ZooKeeper 3.5.5+ with TLS enabled)
+# Set nifi.registry.zookeeper.client.secure=true to enable encrypted ZK connections.
+# The keystore/truststore here are for the ZK channel only and are independent
+# of nifi.registry.security.keystore used for HTTPS traffic.
+nifi.registry.zookeeper.client.secure=false
+nifi.registry.zookeeper.security.keystore=
+nifi.registry.zookeeper.security.keystoreType=JKS
+nifi.registry.zookeeper.security.keystorePasswd=
+nifi.registry.zookeeper.security.truststore=
+nifi.registry.zookeeper.security.truststoreType=JKS
+nifi.registry.zookeeper.security.truststorePasswd=
+
+# Write-replication properties (required when nifi.registry.cluster.coordination=zookeeper) #
+# This node's own HTTP base URL — used to register the node in ZooKeeper and for inter-node
+# write replication.  Must be reachable by all other cluster members.
+# Example: https://node1.example.com:18443
+nifi.registry.cluster.node.address=
+
+# Shared secret added as "X-Registry-Internal-Auth" to leader -> follower replication requests.
+# Must be identical on every cluster node.  Use a long random string (e.g. 64+ hex chars).
+nifi.registry.cluster.node.internal.auth.token=

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -40,6 +40,14 @@
         </resources>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
@@ -215,6 +223,15 @@
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <version>${spring.boot.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- Undertow is used as the embedded servlet container for the Spring Boot management
+             child context when management.server.port is set to a separate port.
+             Tomcat cannot be used here because its JULI logging initializer crashes in the
+             external Jetty classloader environment. Undertow has no such dependency. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+            <version>${spring.boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/ClusterHealthIndicator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/ClusterHealthIndicator.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.actuator;
+
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeAddress;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Spring Boot Actuator health indicator that surfaces cluster state.
+ *
+ * <p>Exposed at {@code /actuator/health} (and {@code /actuator/health/cluster}
+ * when Spring Boot's grouped health is configured). Useful for load balancers
+ * that need to distinguish leaders from followers, or detect a node that has
+ * lost its ZooKeeper connection.
+ *
+ * <p>The overall status is {@code UP} as long as the node is running.
+ * A node that cannot reach ZooKeeper will report {@code leader: false} but
+ * remain {@code UP} — it can still serve reads. Operators should configure
+ * load balancers to route writes only to the leader by checking
+ * {@code details.role}.
+ *
+ * <p>Example output in ZooKeeper cluster mode:
+ * <pre>
+ * {
+ *   "status": "UP",
+ *   "details": {
+ *     "mode":        "zookeeper",
+ *     "role":        "leader",
+ *     "selfId":      "node1",
+ *     "leaderId":    "node1",
+ *     "memberCount": 3,
+ *     "members":     ["node1", "node2", "node3"]
+ *   }
+ * }
+ * </pre>
+ */
+@Component
+public class ClusterHealthIndicator implements HealthIndicator {
+
+    private final NiFiRegistryProperties properties;
+    private final LeaderElectionManager leaderElectionManager;
+    private final NodeRegistry nodeRegistry; // null in non-ZK modes
+
+    @Autowired
+    public ClusterHealthIndicator(final NiFiRegistryProperties properties,
+            final LeaderElectionManager leaderElectionManager,
+            @Autowired(required = false) final NodeRegistry nodeRegistry) {
+        this.properties = properties;
+        this.leaderElectionManager = leaderElectionManager;
+        this.nodeRegistry = nodeRegistry;
+    }
+
+    @Override
+    public Health health() {
+        if (!properties.isClusterEnabled()) {
+            return Health.up()
+                    .withDetail("mode", "standalone")
+                    .build();
+        }
+
+        final boolean isLeader = leaderElectionManager.isLeader();
+        final Health.Builder builder = Health.up()
+                .withDetail("mode", properties.getClusterCoordination())
+                .withDetail("role", isLeader ? "leader" : "follower");
+
+        leaderElectionManager.getLeaderNodeId()
+                .ifPresent(id -> builder.withDetail("leaderId", id));
+
+        if (nodeRegistry != null) {
+            final List<NodeAddress> members = nodeRegistry.getAllNodes();
+            builder.withDetail("selfId", nodeRegistry.getSelfNodeId())
+                    .withDetail("memberCount", members.size())
+                    .withDetail("members", members.stream()
+                            .map(NodeAddress::getNodeId)
+                            .toList());
+        }
+
+        return builder.build();
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/MaintenanceModeEndpoint.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/MaintenanceModeEndpoint.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.actuator;
+
+import org.apache.nifi.registry.web.security.maintenance.MaintenanceModeManager;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Spring Boot Actuator endpoint for managing NiFi Registry maintenance mode.
+ *
+ * <p>Exposed at {@code /actuator/maintenance} and secured by the existing
+ * {@code ResourceAuthorizationFilter} which covers the {@code /actuator} path.
+ *
+ * <p>Usage:
+ * <pre>
+ *   GET  /actuator/maintenance           → returns {"enabled": true|false}
+ *   POST /actuator/maintenance           → body {"enabled": true} enables maintenance mode
+ *                                          body {"enabled": false} disables maintenance mode
+ * </pre>
+ */
+@Component
+@Endpoint(id = "maintenance")
+public class MaintenanceModeEndpoint {
+
+    private final MaintenanceModeManager maintenanceModeManager;
+
+    public MaintenanceModeEndpoint(final MaintenanceModeManager maintenanceModeManager) {
+        this.maintenanceModeManager = maintenanceModeManager;
+    }
+
+    @ReadOperation
+    public Map<String, Object> getMaintenanceModeStatus() {
+        final Map<String, Object> status = new LinkedHashMap<>();
+        status.put("enabled", maintenanceModeManager.isEnabled());
+        return status;
+    }
+
+    @WriteOperation
+    public Map<String, Object> setMaintenanceModeStatus(final boolean enabled) {
+        if (enabled) {
+            maintenanceModeManager.enable();
+        } else {
+            maintenanceModeManager.disable();
+        }
+        final Map<String, Object> status = new LinkedHashMap<>();
+        status.put("enabled", maintenanceModeManager.isEnabled());
+        return status;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/MaintenanceModeHealthIndicator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/MaintenanceModeHealthIndicator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.actuator;
+
+import org.apache.nifi.registry.web.security.maintenance.MaintenanceModeManager;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Boot Actuator health indicator that surfaces maintenance mode state.
+ *
+ * <p>Adds a {@code maintenanceMode} detail to {@code /actuator/health} so that
+ * load balancers and monitoring tools can detect when the instance is in maintenance mode.
+ *
+ * <p>The overall health status remains {@code UP} regardless of maintenance mode because
+ * the instance is still running and serving read traffic. Operators may configure their
+ * load balancer to check the {@code maintenanceMode} detail to stop routing write traffic.
+ */
+@Component
+public class MaintenanceModeHealthIndicator implements HealthIndicator {
+
+    private final MaintenanceModeManager maintenanceModeManager;
+
+    public MaintenanceModeHealthIndicator(final MaintenanceModeManager maintenanceModeManager) {
+        this.maintenanceModeManager = maintenanceModeManager;
+    }
+
+    @Override
+    public Health health() {
+        return Health.up()
+                .withDetail("maintenanceMode", maintenanceModeManager.isEnabled())
+                .build();
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/ManagementServerConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/actuator/ManagementServerConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.actuator;
+
+import org.apache.nifi.registry.web.security.NiFiRegistrySecurityConfig;
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.SearchStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Provides the embedded servlet container required by the Spring Boot management child context
+ * when {@code management.server.port} is set to a different port than the main application.
+ *
+ * <p>In WAR deployments the main application context runs inside an external container
+ * (Jetty). The management child context spins up its own embedded Undertow on the management
+ * port — {@code spring-boot-starter-undertow} must be on the classpath so that Spring Boot's
+ * {@code UndertowServletWebServerFactoryAutoConfiguration} can supply the
+ * {@code ServletWebServerFactory} automatically.
+ *
+ * <p>The management port should be bound to {@code 127.0.0.1} via
+ * {@code management.server.address=127.0.0.1}. This configuration enforces that only
+ * loopback-address requests are permitted; requests from any other address receive a
+ * 403 Forbidden response even if the port is accidentally exposed on a non-loopback
+ * interface. Only Ambari (or other host-local management tooling) should reach this port.
+ */
+@ManagementContextConfiguration(proxyBeanMethods = false)
+public class ManagementServerConfiguration {
+
+    /**
+     * Only active in the management child context (where NiFiRegistrySecurityConfig is not
+     * present in the current context). SearchStrategy.CURRENT prevents this condition from
+     * traversing the parent context hierarchy, where NiFiRegistrySecurityConfig is visible.
+     *
+     * <p>In addition to any {@code management.server.address} binding configured in properties,
+     * this filter chain explicitly rejects requests that do not originate from the loopback
+     * address (127.0.0.1 / ::1) to prevent accidental exposure if the management port is
+     * bound to a non-loopback interface.
+     */
+    @Bean
+    @ConditionalOnMissingBean(value = NiFiRegistrySecurityConfig.class, search = SearchStrategy.CURRENT)
+    public SecurityFilterChain managementSecurityFilterChain(final HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(req -> isLoopbackAddress(req.getRemoteAddr())).permitAll()
+                        .anyRequest().denyAll()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    private static boolean isLoopbackAddress(final String remoteAddr) {
+        if (remoteAddr == null) {
+            return false;
+        }
+        // Fast path: check the two canonical loopback string representations
+        // before incurring the cost of a DNS lookup via InetAddress.getByName().
+        if ("127.0.0.1".equals(remoteAddr) || "::1".equals(remoteAddr)) {
+            return true;
+        }
+        try {
+            return java.net.InetAddress.getByName(remoteAddr).isLoopbackAddress();
+        } catch (final java.net.UnknownHostException e) {
+            return false;
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/NiFiRegistryResourceConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/NiFiRegistryResourceConfig.java
@@ -26,6 +26,7 @@ import org.apache.nifi.registry.web.api.ExtensionRepoResource;
 import org.apache.nifi.registry.web.api.BundleResource;
 import org.apache.nifi.registry.web.api.ExtensionResource;
 import org.apache.nifi.registry.web.api.FlowResource;
+import org.apache.nifi.registry.web.api.InternalSyncResource;
 import org.apache.nifi.registry.web.api.ItemResource;
 import org.apache.nifi.registry.web.api.TenantResource;
 import org.apache.nifi.registry.web.api.RegistryAboutResource;
@@ -72,6 +73,7 @@ public class NiFiRegistryResourceConfig extends ResourceConfig {
         register(TenantResource.class);
         register(ConfigResource.class);
         register(RegistryAboutResource.class);
+        register(InternalSyncResource.class);
 
         // register multipart feature
         register(MultiPartFeature.class);

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/InternalSyncResource.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/InternalSyncResource.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.api;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * Internal JAX-RS resource providing cluster synchronisation endpoints.
+ *
+ * <p>All paths under {@code /internal/} require the shared-secret
+ * {@code X-Registry-Internal-Auth} header set to the value configured in
+ * {@code nifi.registry.cluster.node.internal.auth.token}. Requests without a
+ * valid token receive {@code 403 Forbidden}.
+ *
+ * <p>This resource is only useful when
+ * {@code nifi.registry.cluster.coordination=zookeeper} and the database is H2.
+ * It is registered unconditionally so the endpoint is always present; callers
+ * receive an appropriate error response when the preconditions are not met.
+ */
+@Component
+@Path("/internal/sync")
+public class InternalSyncResource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InternalSyncResource.class);
+
+    private final NiFiRegistryProperties properties;
+    private final LeaderElectionManager leaderElectionManager;
+    private final DataSource dataSource;
+
+    @Autowired
+    public InternalSyncResource(final NiFiRegistryProperties properties,
+            final LeaderElectionManager leaderElectionManager,
+            final DataSource dataSource) {
+        this.properties = properties;
+        this.leaderElectionManager = leaderElectionManager;
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * Returns a complete SQL export (DDL + DML) of the local H2 database.
+     *
+     * <p>Only the current cluster leader should be targeted by this endpoint.
+     * If this node is not the leader, {@code 503 Service Unavailable} is
+     * returned so the caller can retry against a different node.
+     *
+     * <p>The response body is a plain-text SQL script compatible with H2's
+     * {@code RUNSCRIPT FROM} command.  It is generated via H2's built-in
+     * {@code SCRIPT DROP NOPASSWORDS NOSETTINGS} statement.
+     *
+     * @param authToken Value of the {@code X-Registry-Internal-Auth} header.
+     */
+    @GET
+    @Path("/export")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response export(
+            @HeaderParam("X-Registry-Internal-Auth") final String authToken) {
+
+        if (!isValidToken(authToken)) {
+            LOGGER.warn("Rejected /internal/sync/export request: invalid or missing auth token.");
+            return Response.status(Response.Status.FORBIDDEN)
+                    .entity("Invalid or missing X-Registry-Internal-Auth token.")
+                    .build();
+        }
+
+        if (!leaderElectionManager.isLeader()) {
+            LOGGER.info("Rejecting /internal/sync/export: this node is not the current leader.");
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("This node is not the cluster leader. Retry against the leader.")
+                    .build();
+        }
+
+        LOGGER.info("Generating database export script for bootstrap sync.");
+        try {
+            final String script = generateScript();
+            LOGGER.info("Database export script generated ({} bytes).", script.length());
+            return Response.ok(script, MediaType.TEXT_PLAIN).build();
+        } catch (final Exception e) {
+            LOGGER.error("Failed to generate database export script.", e);
+            return Response.serverError()
+                    .entity("Failed to generate export: " + e.getMessage())
+                    .build();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    private boolean isValidToken(final String token) {
+        final String expected = properties.getClusterNodeInternalAuthToken();
+        if (StringUtils.isBlank(expected) || token == null) {
+            return false;
+        }
+        // Constant-time comparison to prevent timing side-channel attacks.
+        return MessageDigest.isEqual(
+                expected.getBytes(StandardCharsets.UTF_8),
+                token.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Executes H2's {@code SCRIPT DROP NOPASSWORDS NOSETTINGS} and returns
+     * the result as a single newline-delimited string.
+     *
+     * <p>This is H2-specific; the endpoint returns {@code 501 Not Implemented}
+     * if the underlying database is not H2.
+     */
+    private String generateScript() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            final String productName = conn.getMetaData().getDatabaseProductName();
+            if (!productName.contains("H2")) {
+                throw new UnsupportedOperationException(
+                        "DB export is only supported for H2 databases, not: " + productName);
+            }
+
+            final StringBuilder sb = new StringBuilder(1024 * 64);
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SCRIPT DROP NOPASSWORDS NOSETTINGS")) {
+                while (rs.next()) {
+                    sb.append(rs.getString(1)).append('\n');
+                }
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -33,6 +33,13 @@ import org.apache.nifi.registry.web.security.authentication.jwt.JwtIdentityProvi
 import org.apache.nifi.registry.web.security.authentication.x509.X509IdentityAuthenticationProvider;
 import org.apache.nifi.registry.web.security.authentication.x509.X509IdentityProvider;
 import org.apache.nifi.registry.web.security.authorization.ResourceAuthorizationFilter;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.cluster.ReplicationClient;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.apache.nifi.registry.web.security.maintenance.MaintenanceModeFilter;
+import org.apache.nifi.registry.web.security.maintenance.MaintenanceModeManager;
+import org.apache.nifi.registry.web.security.replication.WriteReplicationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +86,21 @@ public class NiFiRegistrySecurityConfig {
     private Authorizer authorizer;
 
     @Autowired
+    private MaintenanceModeManager maintenanceModeManager;
+
+    @Autowired
+    private NiFiRegistryProperties properties;
+
+    @Autowired
+    private LeaderElectionManager leaderElectionManager;
+
+    @Autowired(required = false)
+    private NodeRegistry nodeRegistry;
+
+    @Autowired(required = false)
+    private ReplicationClient replicationClient;
+
+    @Autowired
     private X509IdentityProvider x509IdentityProvider;
 
     @Autowired
@@ -91,6 +113,13 @@ public class NiFiRegistrySecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter(), AnonymousAuthenticationFilter.class)
                 // Add Resource Authorization after Spring Security but before Jersey Resources
                 .addFilterAfter(resourceAuthorizationFilter(), AuthorizationFilter.class)
+                // Maintenance mode runs after auth is fully resolved so unauthenticated write requests
+                // are rejected with 401 (not 503) before reaching this filter.
+                .addFilterAfter(maintenanceModeFilter(), ResourceAuthorizationFilter.class)
+                // Write replication: follower forwards to leader; leader fans out to followers.
+                // Runs before ResourceAuthorizationFilter so that leader→follower fan-out requests
+                // bypass per-resource authorization checks (they carry a validated internal token).
+                .addFilterBefore(writeReplicationFilter(), ResourceAuthorizationFilter.class)
                 .anonymous(anonymous -> anonymous.authenticationFilter(new AnonymousIdentityFilter()))
                 .csrf(csrf -> {
                     csrf.requireCsrfProtectionMatcher(new CsrfRequestMatcher());
@@ -110,6 +139,9 @@ public class NiFiRegistrySecurityConfig {
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 )
                 .authorizeRequests((authorize) -> authorize
+                        // Internal leader→follower replication: auth validated by WriteReplicationFilter.
+                        .requestMatchers(req -> req.getHeader(WriteReplicationFilter.REPLICATION_HEADER) != null)
+                        .permitAll()
                         .requestMatchers(
                                 PathPatternRequestMatcher.withDefaults().matcher("/access/token"),
                                 PathPatternRequestMatcher.withDefaults().matcher("/access/token/identity-provider"),
@@ -147,6 +179,18 @@ public class NiFiRegistrySecurityConfig {
 
     private IdentityAuthenticationProvider jwtAuthenticationProvider() {
         return new IdentityAuthenticationProvider(authorizer, jwtIdentityProvider, identityMapper);
+    }
+
+    private MaintenanceModeFilter maintenanceModeFilter() {
+        return new MaintenanceModeFilter(maintenanceModeManager);
+    }
+
+    private WriteReplicationFilter writeReplicationFilter() {
+        return new WriteReplicationFilter(
+                leaderElectionManager,
+                nodeRegistry,
+                replicationClient,
+                properties.getClusterNodeInternalAuthToken());
     }
 
     private ResourceAuthorizationFilter resourceAuthorizationFilter() {

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/maintenance/MaintenanceModeFilter.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/maintenance/MaintenanceModeFilter.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.maintenance;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Servlet filter that enforces maintenance mode by rejecting write operations with HTTP 503.
+ * When maintenance mode is enabled via {@link MaintenanceModeManager}, any request using a
+ * mutating HTTP method (POST, PUT, PATCH, DELETE) is rejected immediately with:
+ * <ul>
+ *   <li>Status: 503 Service Unavailable</li>
+ *   <li>Retry-After: 60 seconds</li>
+ *   <li>Body: plain-text message describing the maintenance mode state</li>
+ * </ul>
+ * Read-only methods (GET, HEAD, OPTIONS) pass through unchanged.
+ */
+public class MaintenanceModeFilter extends GenericFilterBean {
+
+    private static final Set<String> WRITE_METHODS = Set.of("POST", "PUT", "PATCH", "DELETE");
+    private static final String ACTUATOR_PATH_PREFIX = "/actuator/";
+    private static final int RETRY_AFTER_SECONDS = 60;
+    private static final String MAINTENANCE_RESPONSE_BODY = "NiFi Registry is in maintenance mode. Write operations are temporarily disabled. Please try again later.";
+
+    private final MaintenanceModeManager maintenanceModeManager;
+
+    public MaintenanceModeFilter(final MaintenanceModeManager maintenanceModeManager) {
+        this.maintenanceModeManager = maintenanceModeManager;
+    }
+
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
+            final FilterChain filterChain) throws IOException, ServletException {
+        final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+        final HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+
+        if (httpRequest.getServletPath().startsWith(ACTUATOR_PATH_PREFIX)) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        if (maintenanceModeManager.isEnabled() && isWriteMethod(httpRequest.getMethod())) {
+            sendMaintenanceModeResponse(httpResponse);
+            return;
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private boolean isWriteMethod(final String method) {
+        return WRITE_METHODS.contains(method.toUpperCase());
+    }
+
+    private void sendMaintenanceModeResponse(final HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        response.setContentType("text/plain");
+        response.setHeader("Retry-After", String.valueOf(RETRY_AFTER_SECONDS));
+        response.getWriter().println(MAINTENANCE_RESPONSE_BODY);
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/maintenance/MaintenanceModeManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/maintenance/MaintenanceModeManager.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.maintenance;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Manages the maintenance mode state for the NiFi Registry.
+ * When maintenance mode is enabled, write operations are rejected with HTTP 503.
+ */
+@Component
+public class MaintenanceModeManager {
+
+    private final AtomicBoolean maintenanceModeEnabled = new AtomicBoolean(false);
+
+    public void enable() {
+        maintenanceModeEnabled.set(true);
+    }
+
+    public void disable() {
+        maintenanceModeEnabled.set(false);
+    }
+
+    public boolean isEnabled() {
+        return maintenanceModeEnabled.get();
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/replication/WriteReplicationFilter.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/replication/WriteReplicationFilter.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.replication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeAddress;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.cluster.ReplicationClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Servlet filter that implements the NiFi-style write-replication protocol:
+ *
+ * <ol>
+ *   <li><strong>Follower path</strong> — if this node is not the current leader
+ *       it returns a {@code 307 Temporary Redirect} pointing at the leader's URL
+ *       so that the client retries the write directly against the leader.  This
+ *       preserves the client's TLS/mTLS identity end-to-end (unlike transparent
+ *       proxying, which would substitute the follower node's certificate on the
+ *       outbound connection).</li>
+ *   <li><strong>Leader path</strong> — if this node is the leader it lets the
+ *       request proceed through the normal filter/resource chain (writing to
+ *       the local database), then fans out the same request to all followers
+ *       asynchronously so each follower can apply the write to its own local
+ *       database.</li>
+ *   <li><strong>Replicated path</strong> — a request arriving at a follower
+ *       that already carries the {@code X-Registry-Replication: true} header
+ *       is a fan-out from the leader. The filter validates the shared-secret
+ *       {@code X-Registry-Internal-Auth} header and passes the request through
+ *       directly without further forwarding.</li>
+ * </ol>
+ *
+ * <p>This filter is registered before {@link
+ * org.apache.nifi.registry.web.security.authorization.ResourceAuthorizationFilter}
+ * so that leader→follower fan-out requests (carrying a validated internal auth token)
+ * bypass per-resource authorization checks on the receiving follower.
+ *
+ * <p>When the {@link NodeRegistry} or {@link ReplicationClient} is {@code null}
+ * (standalone or database-coordination mode) every request passes through
+ * unchanged.
+ */
+public class WriteReplicationFilter extends GenericFilterBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WriteReplicationFilter.class);
+
+    private static final Set<String> WRITE_METHODS = Set.of("POST", "PUT", "PATCH", "DELETE");
+    private static final String ACTUATOR_PATH_PREFIX = "/actuator/";
+
+    /** Header the leader adds to fan-out requests; prevents forwarding loops. */
+    public static final String REPLICATION_HEADER = "X-Registry-Replication";
+    /** Shared-secret header verifying that a replicated request originates from the leader. */
+    public static final String INTERNAL_AUTH_HEADER = "X-Registry-Internal-Auth";
+
+    private final LeaderElectionManager leaderElectionManager;
+    private final NodeRegistry nodeRegistry;          // null in non-ZK modes
+    private final ReplicationClient replicationClient; // null in non-ZK modes
+    private final String expectedAuthToken;
+
+    public WriteReplicationFilter(final LeaderElectionManager leaderElectionManager,
+            final NodeRegistry nodeRegistry,
+            final ReplicationClient replicationClient,
+            final String expectedAuthToken) {
+        this.leaderElectionManager = leaderElectionManager;
+        this.nodeRegistry = nodeRegistry;
+        this.replicationClient = replicationClient;
+        this.expectedAuthToken = expectedAuthToken;
+    }
+
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
+            final FilterChain chain) throws IOException, ServletException {
+
+        final HttpServletRequest request = (HttpServletRequest) servletRequest;
+        final HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        // 1. Let read-only requests pass through immediately.
+        if (!WRITE_METHODS.contains(request.getMethod())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 2. Actuator writes (health/metrics management) bypass replication.
+        if (request.getServletPath().startsWith(ACTUATOR_PATH_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 3. If cluster replication infrastructure is not active (standalone or
+        //    database-coordination mode), pass through unchanged.
+        if (nodeRegistry == null || replicationClient == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 4. Incoming fan-out from the leader: validate token and apply locally.
+        if (request.getHeader(REPLICATION_HEADER) != null) {
+            if (!isValidInternalAuth(request)) {
+                LOGGER.warn("Received replicated request with invalid or missing '{}' header from {}. Rejecting.",
+                        INTERNAL_AUTH_HEADER, request.getRemoteAddr());
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.setContentType("text/plain");
+                response.getWriter().write("Invalid internal replication auth token.");
+                return;
+            }
+            // Apply the replicated write to this node's local database.
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 5. This node is a follower: redirect the client to the leader.
+        //    Transparent HTTP proxying (forwardToLeader) cannot preserve the client's
+        //    TLS/mTLS identity because the outbound JDK HttpClient connection carries the
+        //    node's own certificate, not the original client certificate.  A 307 Temporary
+        //    Redirect instructs the client (or an intelligent load balancer) to retry the
+        //    write directly against the leader, preserving client credentials end-to-end.
+        if (!leaderElectionManager.isLeader()) {
+            final Optional<NodeAddress> leaderOpt = nodeRegistry.getLeaderAddress();
+            if (leaderOpt.isEmpty()) {
+                LOGGER.warn("Cannot redirect write {} {}: no leader is currently known.",
+                        request.getMethod(), request.getRequestURI());
+                response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+                response.setContentType("text/plain");
+                response.getWriter().write("No cluster leader available. Please retry.");
+                return;
+            }
+            final String path = buildPath(request);
+            // Guard against open-redirect: the request path must begin with '/' to ensure it
+            // is appended as a relative path to the leader's base URL, never as an absolute URL.
+            if (path == null || !path.startsWith("/")) {
+                LOGGER.warn("Rejecting redirect: unexpected request path '{}' does not start with '/'.", path);
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
+            final String leaderUrl = leaderOpt.get().getBaseUrl() + path;
+            LOGGER.debug("Redirecting {} {} to leader '{}' via 307.",
+                    request.getMethod(), request.getRequestURI(), leaderOpt.get().getNodeId());
+            response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
+            response.setHeader("Location", leaderUrl);
+            return;
+        }
+
+        // 6. This node is the leader: process the write locally, then fan out.
+        final ContentCachingRequestWrapper cachedRequest = new ContentCachingRequestWrapper(request);
+        final ContentCachingResponseWrapper cachedResponse = new ContentCachingResponseWrapper(response);
+
+        chain.doFilter(cachedRequest, cachedResponse);
+
+        // Always flush the buffered response body back to the client first.
+        final int status = cachedResponse.getStatus();
+        cachedResponse.copyBodyToResponse();
+
+        // Fan out only on success; a failed write should not be replicated.
+        if (status >= 200 && status < 300) {
+            final List<NodeAddress> followers = nodeRegistry.getOtherNodes();
+            if (!followers.isEmpty()) {
+                final byte[] body = cachedRequest.getContentAsByteArray();
+                final String path = buildPath(request);
+                final Map<String, String> headers = collectHeaders(request);
+                LOGGER.debug("Leader fanning out {} {} to {} follower(s).",
+                        request.getMethod(), path, followers.size());
+                replicationClient.replicateToFollowers(path, request.getMethod(), headers, body, followers);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private boolean isValidInternalAuth(final HttpServletRequest request) {
+        if (expectedAuthToken == null || expectedAuthToken.isBlank()) {
+            // Auth token not configured — cannot validate; reject for safety.
+            return false;
+        }
+        final String received = request.getHeader(INTERNAL_AUTH_HEADER);
+        if (received == null) {
+            return false;
+        }
+        // Constant-time comparison to prevent timing side-channel attacks.
+        return MessageDigest.isEqual(
+                expectedAuthToken.getBytes(StandardCharsets.UTF_8),
+                received.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String buildPath(final HttpServletRequest request) {
+        final String uri = request.getRequestURI();
+        final String query = request.getQueryString();
+        return (query != null && !query.isEmpty()) ? uri + "?" + query : uri;
+    }
+
+    private static Map<String, String> collectHeaders(final HttpServletRequest request) {
+        final Map<String, String> headers = new LinkedHashMap<>();
+        Collections.list(request.getHeaderNames())
+                .forEach(name -> headers.put(name, request.getHeader(name)));
+        return headers;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
@@ -1,0 +1,1 @@
+org.apache.nifi.registry.actuator.ManagementServerConfiguration

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/actuator/TestClusterHealthIndicator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/actuator/TestClusterHealthIndicator.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.actuator;
+
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeAddress;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure Mockito unit tests for {@link ClusterHealthIndicator}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestClusterHealthIndicator {
+
+    @Mock
+    private NiFiRegistryProperties properties;
+
+    @Mock
+    private LeaderElectionManager leaderElectionManager;
+
+    @Mock
+    private NodeRegistry nodeRegistry;
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * In standalone mode (cluster disabled) health should be UP with mode=standalone.
+     */
+    @Test
+    public void testStandaloneModeReturnsUp() {
+        when(properties.isClusterEnabled()).thenReturn(false);
+
+        final ClusterHealthIndicator indicator = new ClusterHealthIndicator(
+                properties, leaderElectionManager, null);
+
+        final Health health = indicator.health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals("standalone", health.getDetails().get("mode"));
+    }
+
+    /**
+     * Cluster mode, follower, nodeRegistry null: UP with role=follower.
+     */
+    @Test
+    public void testClusterModeFollowerNoRegistry() {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.getClusterCoordination()).thenReturn("database");
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+        when(leaderElectionManager.getLeaderNodeId()).thenReturn(Optional.empty());
+
+        final ClusterHealthIndicator indicator = new ClusterHealthIndicator(
+                properties, leaderElectionManager, null);
+
+        final Health health = indicator.health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals("follower", health.getDetails().get("role"));
+    }
+
+    /**
+     * Cluster mode, leader, nodeRegistry null: UP with role=leader.
+     */
+    @Test
+    public void testClusterModeLeaderNoRegistry() {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.getClusterCoordination()).thenReturn("database");
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+        when(leaderElectionManager.getLeaderNodeId()).thenReturn(Optional.empty());
+
+        final ClusterHealthIndicator indicator = new ClusterHealthIndicator(
+                properties, leaderElectionManager, null);
+
+        final Health health = indicator.health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals("leader", health.getDetails().get("role"));
+    }
+
+    /**
+     * Cluster mode with a NodeRegistry present: memberCount and members list
+     * should appear in health details.
+     */
+    @Test
+    public void testClusterModeWithRegistry() {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.getClusterCoordination()).thenReturn("zookeeper");
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+        when(leaderElectionManager.getLeaderNodeId()).thenReturn(Optional.empty());
+
+        final List<NodeAddress> members = List.of(
+                new NodeAddress("node1", "http://node1:18080"),
+                new NodeAddress("node2", "http://node2:18080"),
+                new NodeAddress("node3", "http://node3:18080"));
+        when(nodeRegistry.getAllNodes()).thenReturn(members);
+        when(nodeRegistry.getSelfNodeId()).thenReturn("node1");
+
+        final ClusterHealthIndicator indicator = new ClusterHealthIndicator(
+                properties, leaderElectionManager, nodeRegistry);
+
+        final Health health = indicator.health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals(3, health.getDetails().get("memberCount"));
+
+        @SuppressWarnings("unchecked")
+        final List<String> memberIds = (List<String>) health.getDetails().get("members");
+        assertNotNull(memberIds);
+        assertEquals(3, memberIds.size());
+        assertTrue(memberIds.contains("node1"));
+        assertTrue(memberIds.contains("node2"));
+        assertTrue(memberIds.contains("node3"));
+    }
+
+    /**
+     * When getLeaderNodeId() returns a non-empty optional, the leaderId detail
+     * should be present in the health response.
+     */
+    @Test
+    public void testLeaderIdPresentWhenAvailable() {
+        when(properties.isClusterEnabled()).thenReturn(true);
+        when(properties.getClusterCoordination()).thenReturn("zookeeper");
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+        when(leaderElectionManager.getLeaderNodeId()).thenReturn(Optional.of("node1"));
+
+        final ClusterHealthIndicator indicator = new ClusterHealthIndicator(
+                properties, leaderElectionManager, null);
+
+        final Health health = indicator.health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals("node1", health.getDetails().get("leaderId"));
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/TestInternalSyncResource.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/TestInternalSyncResource.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.api;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure Mockito unit tests for {@link InternalSyncResource}.
+ *
+ * <p>No Spring context is loaded. DataSource → Connection → MetaData / Statement
+ * chains are stubbed to control the behaviour of
+ * {@link InternalSyncResource#export(String)}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestInternalSyncResource {
+
+    private static final String VALID_TOKEN = "shared-secret-token";
+
+    @Mock
+    private NiFiRegistryProperties properties;
+
+    @Mock
+    private LeaderElectionManager leaderElectionManager;
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private DatabaseMetaData databaseMetaData;
+
+    @Mock
+    private Statement statement;
+
+    @Mock
+    private ResultSet resultSet;
+
+    private InternalSyncResource resource;
+
+    @BeforeEach
+    public void setup() {
+        resource = new InternalSyncResource(properties, leaderElectionManager, dataSource);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Null auth token should return 403 Forbidden without touching the database.
+     */
+    @Test
+    public void testMissingTokenReturnsForbidden() {
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn(VALID_TOKEN);
+
+        final Response response = resource.export(null);
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * A wrong auth token should return 403 Forbidden.
+     */
+    @Test
+    public void testWrongTokenReturnsForbidden() {
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn(VALID_TOKEN);
+
+        final Response response = resource.export("wrong-token");
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * A correct token but this node is not the leader should return 503.
+     */
+    @Test
+    public void testNotLeaderReturnsServiceUnavailable() {
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn(VALID_TOKEN);
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+
+        final Response response = resource.export(VALID_TOKEN);
+
+        assertEquals(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * When the underlying database is not H2, the export should return a
+     * server error (500) containing an explanatory message.
+     */
+    @Test
+    public void testNonH2DatabaseThrowsUnsupported() throws Exception {
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn(VALID_TOKEN);
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn("PostgreSQL");
+
+        final Response response = resource.export(VALID_TOKEN);
+
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        assertNotNull(response.getEntity());
+        assertTrue(response.getEntity().toString().contains("PostgreSQL"),
+                "Error message should mention the unsupported DB type");
+    }
+
+    /**
+     * Happy path: valid token, this node is the leader, H2 database.
+     * The response should be 200 with the two SQL script lines concatenated.
+     */
+    @Test
+    public void testLeaderReturnsScript() throws Exception {
+        when(properties.getClusterNodeInternalAuthToken()).thenReturn(VALID_TOKEN);
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn("H2");
+
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SCRIPT DROP NOPASSWORDS NOSETTINGS")).thenReturn(resultSet);
+
+        // ResultSet returns two rows then signals end-of-results.
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString(1))
+                .thenReturn("CREATE TABLE FOO (ID INT);")
+                .thenReturn("INSERT INTO FOO VALUES (1);");
+
+        final Response response = resource.export(VALID_TOKEN);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        final String body = (String) response.getEntity();
+        assertNotNull(body);
+        assertTrue(body.contains("CREATE TABLE FOO"), "Response should contain CREATE TABLE statement");
+        assertTrue(body.contains("INSERT INTO FOO"), "Response should contain INSERT statement");
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/security/replication/TestWriteReplicationFilter.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/security/replication/TestWriteReplicationFilter.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.replication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.nifi.registry.cluster.LeaderElectionManager;
+import org.apache.nifi.registry.cluster.NodeAddress;
+import org.apache.nifi.registry.cluster.NodeRegistry;
+import org.apache.nifi.registry.cluster.ReplicationClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure unit tests for {@link WriteReplicationFilter}.
+ *
+ * <p>Uses Spring {@link MockHttpServletRequest} / {@link MockHttpServletResponse}
+ * so no servlet container is needed. All cluster dependencies are Mockito mocks.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestWriteReplicationFilter {
+
+    private static final String EXPECTED_AUTH_TOKEN = "test-token-abc";
+
+    @Mock
+    private LeaderElectionManager leaderElectionManager;
+
+    @Mock
+    private NodeRegistry nodeRegistry;
+
+    @Mock
+    private ReplicationClient replicationClient;
+
+    private WriteReplicationFilter filter;
+
+    @BeforeEach
+    public void setup() {
+        filter = new WriteReplicationFilter(
+                leaderElectionManager, nodeRegistry, replicationClient, EXPECTED_AUTH_TOKEN);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * GET requests should pass through without replication logic.
+     */
+    @Test
+    public void testGetRequestPassesThrough() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nifi-registry-api/buckets");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest(), "Filter chain should have been called for GET");
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * POST to an actuator path should bypass replication entirely.
+     */
+    @Test
+    public void testActuatorPathPassesThrough() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/actuator/health");
+        request.setServletPath("/actuator/health");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest(), "Filter chain should have been called for actuator path");
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * When nodeRegistry is null (standalone or database-coordination mode)
+     * a POST request should pass through unchanged.
+     */
+    @Test
+    public void testNullNodeRegistryPassesThrough() throws Exception {
+        final WriteReplicationFilter standaloneFilter = new WriteReplicationFilter(
+                leaderElectionManager, null, null, EXPECTED_AUTH_TOKEN);
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        standaloneFilter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest(), "Filter chain should have been called when nodeRegistry is null");
+    }
+
+    /**
+     * A replicated request with the correct auth token should pass through
+     * without being forwarded again (prevents forwarding loops).
+     */
+    @Test
+    public void testReplicatedRequestValidTokenPassesThrough() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        request.addHeader(WriteReplicationFilter.REPLICATION_HEADER, "true");
+        request.addHeader(WriteReplicationFilter.INTERNAL_AUTH_HEADER, EXPECTED_AUTH_TOKEN);
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest(), "Replicated request with valid token should pass through");
+        assertEquals(200, response.getStatus());
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * A replicated request with a wrong auth token should be rejected with 403.
+     */
+    @Test
+    public void testReplicatedRequestInvalidTokenReturnsForbidden() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        request.addHeader(WriteReplicationFilter.REPLICATION_HEADER, "true");
+        request.addHeader(WriteReplicationFilter.INTERNAL_AUTH_HEADER, "wrong-token");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+    }
+
+    /**
+     * A replicated request missing the auth header entirely should return 403.
+     */
+    @Test
+    public void testReplicatedRequestMissingTokenReturnsForbidden() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        request.addHeader(WriteReplicationFilter.REPLICATION_HEADER, "true");
+        // No INTERNAL_AUTH_HEADER set.
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+    }
+
+    /**
+     * When this node is a follower it should return a 307 redirect to the leader
+     * so the client can re-send its request with its own TLS/mTLS identity intact.
+     */
+    @Test
+    public void testFollowerRedirectsToLeader() throws Exception {
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+        final NodeAddress leaderAddress = new NodeAddress("leader", "http://leader:18080");
+        when(nodeRegistry.getLeaderAddress()).thenReturn(Optional.of(leaderAddress));
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_TEMPORARY_REDIRECT, response.getStatus());
+        assertEquals("http://leader:18080/nifi-registry-api/buckets", response.getHeader("Location"));
+        // Chain must NOT be called — follower does not process the write locally.
+        assertTrue(chain.getRequest() == null, "Filter chain should NOT have been called for follower redirect");
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * Query parameters must be preserved in the redirect Location.
+     */
+    @Test
+    public void testFollowerRedirectPreservesQueryString() throws Exception {
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+        final NodeAddress leaderAddress = new NodeAddress("leader", "http://leader:18080");
+        when(nodeRegistry.getLeaderAddress()).thenReturn(Optional.of(leaderAddress));
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("PUT", "/nifi-registry-api/buckets/123");
+        request.setQueryString("version=2");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(HttpServletResponse.SC_TEMPORARY_REDIRECT, response.getStatus());
+        assertEquals("http://leader:18080/nifi-registry-api/buckets/123?version=2",
+                response.getHeader("Location"));
+    }
+
+    /**
+     * When this node is a follower and no leader is known, return 503.
+     */
+    @Test
+    public void testFollowerNoLeaderReturns503() throws Exception {
+        when(leaderElectionManager.isLeader()).thenReturn(false);
+        when(nodeRegistry.getLeaderAddress()).thenReturn(Optional.empty());
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.getStatus());
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * When this node is the leader and the request succeeds (2xx), it should
+     * fan out to followers via replicateToFollowers().
+     */
+    @Test
+    public void testLeaderFansOutOn2xx() throws Exception {
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+        final NodeAddress follower = new NodeAddress("follower-1", "http://follower:18080");
+        when(nodeRegistry.getOtherNodes()).thenReturn(List.of(follower));
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        request.setContent("{\"name\":\"test\"}".getBytes());
+
+        // Use a FilterChain that sets a 201 response.
+        final FilterChain chain201 = (req, res) ->
+                ((HttpServletResponse) res).setStatus(201);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, chain201);
+
+        verify(replicationClient).replicateToFollowers(anyString(), anyString(), any(), any(), anyList());
+    }
+
+    /**
+     * When this node is the leader and the request fails (4xx), it must NOT
+     * fan out to followers.
+     */
+    @Test
+    public void testLeaderDoesNotFanOutOn4xx() throws Exception {
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        request.setContent("{}".getBytes());
+
+        // FilterChain sets 400 Bad Request.
+        final FilterChain chain400 = (req, res) ->
+                ((HttpServletResponse) res).setStatus(400);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, chain400);
+
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+
+    /**
+     * When this node is the leader and the request fails (5xx), it must NOT
+     * fan out to followers.
+     */
+    @Test
+    public void testLeaderDoesNotFanOutOn5xx() throws Exception {
+        when(leaderElectionManager.isLeader()).thenReturn(true);
+
+        final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nifi-registry-api/buckets");
+        request.setContent("{}".getBytes());
+
+        // FilterChain sets 500 Internal Server Error.
+        final FilterChain chain500 = (req, res) ->
+                ((HttpServletResponse) res).setStatus(500);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, chain500);
+
+        verify(replicationClient, never()).replicateToFollowers(any(), any(), any(), any(), any());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <!-- Big data platforms -->
         <hadoop.version>3.3.6.3.3.6.4-1</hadoop.version>
         <ozone.version>1.4.1.3.3.6.4-1</ozone.version>
+        <zookeeper.version>3.8.4.3.3.6.4-1</zookeeper.version>
 
         <!-- Kubernetes -->
         <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
@@ -206,6 +207,7 @@
         <pmd.version>7.19.0</pmd.version>
         <checkstyle.version>12.2.0</checkstyle.version>
         <testcontainers.version>2.0.2</testcontainers.version>
+        <curator.version>5.9.0</curator.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
HA Configuration — Three NiFi Registry Nodes                                                                                                                                   
                                                                                                                                                                                 
  There are four files to change on each node (the database connection and cluster flags are the only per-node differences).                                                     
                                                                                                                                                                                 
  Overview

  [Load Balancer]
     /    |    \
  Node-1  Node-2  Node-3
     \    |    /
     [PostgreSQL]

  All three nodes point at the same DB. The DB holds:
  - Metadata (buckets, flows, versions)
  - Users & groups / access policies (DB-backed providers)
  - Flow content (DB-backed persistence provider)
  - Cache version counters (CACHE_VERSION)
  - Leader election lock (CLUSTER_LEADER)
  - Durable event log (REGISTRY_EVENT)

  ---
  File 1 — conf/nifi-registry.properties

  This is the main config file. The DB section and the cluster section both live here. Everything below is the same on all three nodes except
  nifi.registry.cluster.node.identifier.

  #### ── Database (same on all nodes) ──────────────────────────────────────────────
  nifi.registry.db.url=jdbc:postgresql://pg-host:5432/nifi_registry
  nifi.registry.db.driver.class=org.postgresql.Driver
  nifi.registry.db.driver.directory=./lib/postgresql   # dir containing the JDBC jar
  nifi.registry.db.username=nifireg
  nifi.registry.db.password=secret
  nifi.registry.db.maxConnections=5

  #### ── Cluster (change node.identifier per node) ─────────────────────────────────
  nifi.registry.cluster.enabled=true
  nifi.registry.cluster.node.identifier=node-1          # → node-2 / node-3 on the others
  nifi.registry.cluster.cache.refresh.interval.ms=15000

  The DB URL is the only place you configure the database. The providers (authorizers.xml, providers.xml) simply say "use the database" — they don't repeat the connection
  details, because the framework injects the same DataSource bean into them automatically.

  ---
  File 2 — conf/providers.xml

  Switch flow storage from the default filesystem provider to the database provider. Identical on all three nodes.

  <providers>
      <!-- Use DB instead of local filesystem so all nodes share flow content -->
      <flowPersistenceProvider>
          <class>org.apache.nifi.registry.provider.flow.DatabaseFlowPersistenceProvider</class>
      </flowPersistenceProvider>

      <!-- Extension bundle storage: also switch to S3 or keep filesystem+shared-NFS.
           Filesystem only works if all nodes mount the same directory. -->
      <extensionBundlePersistenceProvider>
          <class>org.apache.nifi.registry.provider.extension.FileSystemBundlePersistenceProvider</class>
          <property name="Extension Bundle Storage Directory">./extension_bundles</property>
      </extensionBundlePersistenceProvider>
  </providers>

  Note on extension bundles: If you use the filesystem provider for bundles, mount the same NFS/EFS directory on every node. Or switch to S3 (S3BundlePersistenceProvider) for a
  fully shared, filesystem-free setup.

  ---
  File 3 — conf/authorizers.xml

  Switch from the default file-backed providers to the DB-backed ones. Identical on all three nodes. Fill in your actual admin identity.

  <authorizers>

      <!-- Users & groups live in the DB (UGP_USER / UGP_GROUP tables) -->
      <userGroupProvider>
          <identifier>database-user-group-provider</identifier>
          <class>org.apache.nifi.registry.security.authorization.database.DatabaseUserGroupProvider</class>
          <property name="Initial User Identity 1">CN=admin, OU=nifi</property>
      </userGroupProvider>

      <!-- Access policies live in the DB (APP_POLICY tables) -->
      <accessPolicyProvider>
          <identifier>database-access-policy-provider</identifier>
          <class>org.apache.nifi.registry.security.authorization.database.DatabaseAccessPolicyProvider</class>
          <property name="User Group Provider">database-user-group-provider</property>
          <property name="Initial Admin Identity">CN=admin, OU=nifi</property>
          <!-- Add NiFi node identities if NiFi itself connects to this Registry -->
          <property name="NiFi Identity 1">CN=nifi-node-1, OU=nifi</property>
      </accessPolicyProvider>

      <authorizer>
          <identifier>managed-authorizer</identifier>
          <class>org.apache.nifi.registry.security.authorization.StandardManagedAuthorizer</class>
          <property name="Access Policy Provider">database-access-policy-provider</property>
      </authorizer>

  </authorizers>

  Also confirm nifi-registry.properties points to this authorizer:
  nifi.registry.security.authorizer=managed-authorizer

  ---
  File 4 — lib/postgresql/ (JDBC driver)

  Drop the PostgreSQL JDBC jar into a directory on every node and point nifi.registry.db.driver.directory at it (done in File 1 above). No XML needed — just the jar file.

  ---
  What happens on first start

  1. Node-1 starts first. Flyway runs all migrations (V2–V10) and creates all tables, including CACHE_VERSION, CLUSTER_LEADER, and REGISTRY_EVENT. Node-1 wins the INSERT into
  CLUSTER_LEADER and becomes leader.
  2. Node-2 and Node-3 start. Flyway detects all migrations are already applied and skips them. Their heartbeat threads try to INSERT into CLUSTER_LEADER but fail (row exists
  and Node-1 holds the lease), so they become followers.
  3. All three nodes poll CACHE_VERSION every 15 s. When any node mutates users/groups/policies, it bumps the version and the other two reload their in-memory caches within 15
  s.
  4. If Node-1 dies, Node-2 or Node-3 claims the expired lease within 30 s and takes over event delivery.

  ---
  Summary of what goes where

| Setting | Where |
|----------|----------|
| Database URL, driver, username, password         | nifi-registry.properties                          |
| cluster.enabled, node.identifier, cache interval | nifi-registry.properties                          |
| Flow persistence provider (DB vs filesystem)     | providers.xml                                     |
| User/group + policy providers (DB vs file)       | authorizers.xml                                   |
| PostgreSQL JDBC jar                              | lib/postgresql/ dir on each node                  |
| Nothing else                                     | — no extra XML, no ZooKeeper, no NiFi cluster.xml |

