### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <logback.version>1.3.14</logback.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <netty.4.version>4.1.127.Final</netty.4.version>
+        <netty.4.version>4.1.132.Final</netty.4.version>
         <spring.version>5.3.39</spring.version>
         <spring.security.version>5.8.15</spring.security.version>
         <gcp.sdk.version>26.77.0</gcp.sdk.version>


### PR DESCRIPTION
This patch was tested locally.