### PR TITLE
ODP-6404: Backport commits from rel/ODP-3.3.6.2-104 to rel/ODP-3.3.6.4-1 for Verizon

### DIFF
--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.nifi.processors.gcp.util.GoogleUtils.GOOGLE_CLOUD_PLATFORM_SCOPE;
+import static org.apache.nifi.processors.gcp.util.GoogleUtils.GOOGLE_CLOUD_BIGQUERY_SCOPE;
 
 /**
  * Base class for creating processors that connect to GCP BiqQuery service
@@ -105,7 +105,7 @@ public abstract class AbstractBigQueryProcessor extends AbstractGCPProcessor<Big
 
     @Override
     protected GoogleCredentials getGoogleCredentials(ProcessContext context) {
-        return super.getGoogleCredentials(context).createScoped(GOOGLE_CLOUD_PLATFORM_SCOPE);
+        return super.getGoogleCredentials(context).createScoped(GOOGLE_CLOUD_BIGQUERY_SCOPE);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -32,8 +32,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import com.google.api.services.drive.model.User;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -66,15 +69,23 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_M
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_CONTENT_LINK;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_CONTENT_LINK_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIEW_LINK;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIEW_LINK_DESC;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"google", "drive", "storage", "fetch"})
@@ -91,6 +102,10 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTA
         @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
         @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
         @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
+        @WritesAttribute(attribute = OWNER, description = OWNER_DESC),
+        @WritesAttribute(attribute = LAST_MODIFYING_USER, description = LAST_MODIFYING_USER_DESC),
+        @WritesAttribute(attribute = WEB_VIEW_LINK, description = WEB_VIEW_LINK_DESC),
+        @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })
@@ -269,7 +284,13 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         final long startNanos = System.nanoTime();
         try {
             final File fileMetadata = fetchFileMetadata(fileId);
-            final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata).build().toAttributeMap();
+            final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata)
+                    .owner(Optional.ofNullable(fileMetadata.getOwners()).filter(owners -> !owners.isEmpty()).map(List::getFirst).map(User::getDisplayName).orElse(null))
+                    .lastModifyingUser(Optional.ofNullable(fileMetadata.getLastModifyingUser()).map(User::getDisplayName).orElse(null))
+                    .webViewLink(fileMetadata.getWebViewLink())
+                    .webContentLink(fileMetadata.getWebContentLink())
+                    .build()
+                    .toAttributeMap();
 
             flowFile = fetchFile(fileMetadata, session, context, flowFile, attributeMap);
 
@@ -392,7 +413,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
                 .files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks, owners, lastModifyingUser, webViewLink, webContentLink")
                 .execute();
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -57,6 +57,8 @@ import org.apache.nifi.processors.gcp.ProxyAwareTransportFactory;
 import org.apache.nifi.processors.gcp.util.GoogleUtils;
 import org.apache.nifi.proxy.ProxyConfiguration;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
@@ -65,6 +67,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAM
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
@@ -85,6 +89,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTA
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = SIZE_AVAILABLE, description = SIZE_AVAILABLE_DESC),
         @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
+        @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })
@@ -263,7 +269,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         final long startNanos = System.nanoTime();
         try {
             final File fileMetadata = fetchFileMetadata(fileId);
-            final Map<String, String> attributeMap = createAttributeMap(fileMetadata);
+            final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata).build().toAttributeMap();
 
             flowFile = fetchFile(fileMetadata, session, context, flowFile, attributeMap);
 
@@ -386,7 +392,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
                 .files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
                 .execute();
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -71,11 +71,20 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_NAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_NAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
@@ -106,10 +115,17 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIE
         @WritesAttribute(attribute = LAST_MODIFYING_USER, description = LAST_MODIFYING_USER_DESC),
         @WritesAttribute(attribute = WEB_VIEW_LINK, description = WEB_VIEW_LINK_DESC),
         @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC),
+        @WritesAttribute(attribute = PARENT_FOLDER_ID, description = PARENT_FOLDER_ID_DESC),
+        @WritesAttribute(attribute = PARENT_FOLDER_NAME, description = PARENT_FOLDER_NAME_DESC),
+        @WritesAttribute(attribute = SHARED_DRIVE_ID, description = SHARED_DRIVE_ID_DESC),
+        @WritesAttribute(attribute = SHARED_DRIVE_NAME, description = SHARED_DRIVE_NAME_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })
 public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTrait {
+
+    static final String FILE_METADATA_FIELDS_BASIC = "id, name, createdTime, modifiedTime, mimeType, size, exportLinks";
+    static final String FILE_METADATA_FIELDS_EXTENDED = FILE_METADATA_FIELDS_BASIC + ", owners, lastModifyingUser, webViewLink, webContentLink, parents";
 
     private static final long EXPORT_SIZE_LIMIT = 10_000_000;
     private static final String EXPORT_SIZE_ERROR = "exportSizeLimitExceeded";
@@ -283,12 +299,30 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
 
         final long startNanos = System.nanoTime();
         try {
-            final File fileMetadata = fetchFileMetadata(fileId);
-            final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata)
-                    .owner(Optional.ofNullable(fileMetadata.getOwners()).filter(owners -> !owners.isEmpty()).map(owners -> owners.get(0)).map(User::getDisplayName).orElse(null))
-                    .lastModifyingUser(Optional.ofNullable(fileMetadata.getLastModifyingUser()).map(User::getDisplayName).orElse(null))
-                    .webViewLink(fileMetadata.getWebViewLink())
-                    .webContentLink(fileMetadata.getWebContentLink())
+            final boolean listedFile = flowFile.getAttributes().containsKey(LISTED_FOLDER_ID);
+
+            final File fileMetadata = fetchFileMetadata(fileId, listedFile ? FILE_METADATA_FIELDS_BASIC : FILE_METADATA_FIELDS_EXTENDED);
+            final GoogleDriveFileInfo.Builder fileInfoBuilder = createGoogleDriveFileInfoBuilder(fileMetadata);
+
+            if (!listedFile) {
+                fileInfoBuilder
+                        .owner(Optional.ofNullable(fileMetadata.getOwners()).filter(owners -> !owners.isEmpty()).map(owners -> owners.get(0)).map(User::getDisplayName).orElse(null))
+                        .lastModifyingUser(Optional.ofNullable(fileMetadata.getLastModifyingUser()).map(User::getDisplayName).orElse(null))
+                        .webViewLink(fileMetadata.getWebViewLink())
+                        .webContentLink(fileMetadata.getWebContentLink());
+
+                Optional.ofNullable(fileMetadata.getParents())
+                        .filter(parents -> !parents.isEmpty())
+                        .map(List::getFirst)
+                        .map(folderId -> getFolderDetails(driveService, folderId))
+                        .ifPresent(folderDetails -> fileInfoBuilder
+                                .parentFolderId(folderDetails.getFolderId())
+                                .parentFolderName(folderDetails.getFolderName())
+                                .sharedDriveId(folderDetails.getSharedDriveId())
+                                .sharedDriveName(folderDetails.getSharedDriveName()));
+            }
+
+            final Map<String, String> attributeMap = fileInfoBuilder
                     .build()
                     .toAttributeMap();
 
@@ -359,7 +393,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
 
         final String fileExtension = fileExtensions.get(exportMimeType);
         if (fileExtension != null) {
-            attributeMap.put(CoreAttributes.FILENAME.key(), flowFile.getAttribute(CoreAttributes.FILENAME.key()) + fileExtension);
+            attributeMap.put(CoreAttributes.FILENAME.key(), attributeMap.get(CoreAttributes.FILENAME.key()) + fileExtension);
         }
 
         if (fileMetadata.getSize() == null || fileMetadata.getSize() < EXPORT_SIZE_LIMIT) {
@@ -408,12 +442,12 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         return exportLink;
     }
 
-    private File fetchFileMetadata(final String fileId) throws IOException {
+    private File fetchFileMetadata(final String fileId, final String fields) throws IOException {
         return driveService
                 .files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks, owners, lastModifyingUser, webViewLink, webContentLink")
+                .setFields(fields)
                 .execute();
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -313,7 +313,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
 
                 Optional.ofNullable(fileMetadata.getParents())
                         .filter(parents -> !parents.isEmpty())
-                        .map(List::getFirst)
+                        .map(parents -> parents.get(0))
                         .map(folderId -> getFolderDetails(driveService, folderId))
                         .ifPresent(folderDetails -> fileInfoBuilder
                                 .parentFolderId(folderDetails.getFolderId())

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -285,7 +285,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         try {
             final File fileMetadata = fetchFileMetadata(fileId);
             final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata)
-                    .owner(Optional.ofNullable(fileMetadata.getOwners()).filter(owners -> !owners.isEmpty()).map(List::getFirst).map(User::getDisplayName).orElse(null))
+                    .owner(Optional.ofNullable(fileMetadata.getOwners()).filter(owners -> !owners.isEmpty()).map(owners -> owners.get(0)).map(User::getDisplayName).orElse(null))
                     .lastModifyingUser(Optional.ofNullable(fileMetadata.getLastModifyingUser()).map(User::getDisplayName).orElse(null))
                     .webViewLink(fileMetadata.getWebViewLink())
                     .webContentLink(fileMetadata.getWebContentLink())

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -57,8 +57,6 @@ import org.apache.nifi.processors.gcp.ProxyAwareTransportFactory;
 import org.apache.nifi.processors.gcp.util.GoogleUtils;
 import org.apache.nifi.proxy.ProxyConfiguration;
 
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
@@ -67,8 +65,6 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAM
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
@@ -89,8 +85,6 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTA
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = SIZE_AVAILABLE, description = SIZE_AVAILABLE_DESC),
         @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
-        @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
-        @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })
@@ -269,7 +263,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         final long startNanos = System.nanoTime();
         try {
             final File fileMetadata = fetchFileMetadata(fileId);
-            final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata).build().toAttributeMap();
+            final Map<String, String> attributeMap = createAttributeMap(fileMetadata);
 
             flowFile = fetchFile(fileMetadata, session, context, flowFile, attributeMap);
 
@@ -392,7 +386,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
                 .files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, mimeType, size, exportLinks")
                 .execute();
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
@@ -63,6 +63,18 @@ public class GoogleDriveAttributes {
     public static final String WEB_CONTENT_LINK = "drive.web.content.link";
     public static final String WEB_CONTENT_LINK_DESC = "Web content link to the file";
 
+    public static final String PARENT_FOLDER_ID = "drive.parent.folder.id";
+    public static final String PARENT_FOLDER_ID_DESC = "The id of the file's parent folder";
+
+    public static final String PARENT_FOLDER_NAME = "drive.parent.folder.name";
+    public static final String PARENT_FOLDER_NAME_DESC = "The name of the file's parent folder";
+
+    public static final String LISTED_FOLDER_ID = "drive.listed.folder.id";
+    public static final String LISTED_FOLDER_ID_DESC = "The id of the base folder that was listed";
+
+    public static final String LISTED_FOLDER_NAME = "drive.listed.folder.name";
+    public static final String LISTED_FOLDER_NAME_DESC = "The name of the base folder that was listed";
+
     public static final String ERROR_MESSAGE = "error.message";
     public static final String ERROR_MESSAGE_DESC = "The error message returned by Google Drive";
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
@@ -75,6 +75,12 @@ public class GoogleDriveAttributes {
     public static final String LISTED_FOLDER_NAME = "drive.listed.folder.name";
     public static final String LISTED_FOLDER_NAME_DESC = "The name of the base folder that was listed";
 
+    public static final String SHARED_DRIVE_ID = "drive.shared.drive.id";
+    public static final String SHARED_DRIVE_ID_DESC = "The id of the shared drive (if the file is located on a shared drive)";
+
+    public static final String SHARED_DRIVE_NAME = "drive.shared.drive.name";
+    public static final String SHARED_DRIVE_NAME_DESC = "The name of the shared drive (if the file is located on a shared drive)";
+
     public static final String ERROR_MESSAGE = "error.message";
     public static final String ERROR_MESSAGE_DESC = "The error message returned by Google Drive";
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
@@ -43,6 +43,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
@@ -72,6 +74,8 @@ public class GoogleDriveFileInfo implements ListableEntity {
         recordFields.add(new RecordField(PARENT_FOLDER_NAME, RecordFieldType.STRING.getDataType(), true));
         recordFields.add(new RecordField(LISTED_FOLDER_ID, RecordFieldType.STRING.getDataType(), true));
         recordFields.add(new RecordField(LISTED_FOLDER_NAME, RecordFieldType.STRING.getDataType(), true));
+        recordFields.add(new RecordField(SHARED_DRIVE_ID, RecordFieldType.STRING.getDataType(), true));
+        recordFields.add(new RecordField(SHARED_DRIVE_NAME, RecordFieldType.STRING.getDataType(), true));
 
         SCHEMA = new SimpleRecordSchema(recordFields);
     }
@@ -94,6 +98,8 @@ public class GoogleDriveFileInfo implements ListableEntity {
     private final String parentFolderName;
     private final String listedFolderId;
     private final String listedFolderName;
+    private final String sharedDriveId;
+    private final String sharedDriveName;
 
     public String getId() {
         return id;
@@ -155,6 +161,14 @@ public class GoogleDriveFileInfo implements ListableEntity {
         return listedFolderName;
     }
 
+    public String getSharedDriveId() {
+        return sharedDriveId;
+    }
+
+    public String getSharedDriveName() {
+        return sharedDriveName;
+    }
+
     @Override
     public Record toRecord() {
         return new MapRecord(SCHEMA, toMap());
@@ -180,6 +194,8 @@ public class GoogleDriveFileInfo implements ListableEntity {
         values.put(PARENT_FOLDER_NAME, getParentFolderName());
         values.put(LISTED_FOLDER_ID, getListedFolderId());
         values.put(LISTED_FOLDER_NAME, getListedFolderName());
+        values.put(SHARED_DRIVE_ID, getSharedDriveId());
+        values.put(SHARED_DRIVE_NAME, getSharedDriveName());
 
         return values;
     }
@@ -214,6 +230,8 @@ public class GoogleDriveFileInfo implements ListableEntity {
         private String parentFolderName;
         private String listedFolderId;
         private String listedFolderName;
+        private String sharedDriveId;
+        private String sharedDriveName;
 
         public Builder id(String id) {
             this.id = id;
@@ -295,6 +313,16 @@ public class GoogleDriveFileInfo implements ListableEntity {
             return this;
         }
 
+        public Builder sharedDriveId(String sharedDriveId) {
+            this.sharedDriveId = sharedDriveId;
+            return this;
+        }
+
+        public Builder sharedDriveName(String sharedDriveName) {
+            this.sharedDriveName = sharedDriveName;
+            return this;
+        }
+
         public GoogleDriveFileInfo build() {
             return new GoogleDriveFileInfo(this);
         }
@@ -348,6 +376,8 @@ public class GoogleDriveFileInfo implements ListableEntity {
         this.parentFolderName = builder.parentFolderName;
         this.listedFolderId = builder.listedFolderId;
         this.listedFolderName = builder.listedFolderName;
+        this.sharedDriveId = builder.sharedDriveId;
+        this.sharedDriveName = builder.sharedDriveName;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFileInfo.java
@@ -35,9 +35,13 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
@@ -64,6 +68,10 @@ public class GoogleDriveFileInfo implements ListableEntity {
         recordFields.add(new RecordField(LAST_MODIFYING_USER, RecordFieldType.STRING.getDataType(), true));
         recordFields.add(new RecordField(WEB_VIEW_LINK, RecordFieldType.STRING.getDataType(), true));
         recordFields.add(new RecordField(WEB_CONTENT_LINK, RecordFieldType.STRING.getDataType(), true));
+        recordFields.add(new RecordField(PARENT_FOLDER_ID, RecordFieldType.STRING.getDataType(), true));
+        recordFields.add(new RecordField(PARENT_FOLDER_NAME, RecordFieldType.STRING.getDataType(), true));
+        recordFields.add(new RecordField(LISTED_FOLDER_ID, RecordFieldType.STRING.getDataType(), true));
+        recordFields.add(new RecordField(LISTED_FOLDER_NAME, RecordFieldType.STRING.getDataType(), true));
 
         SCHEMA = new SimpleRecordSchema(recordFields);
     }
@@ -81,6 +89,11 @@ public class GoogleDriveFileInfo implements ListableEntity {
     private final String lastModifyingUser;
     private final String webViewLink;
     private final String webContentLink;
+
+    private final String parentFolderId;
+    private final String parentFolderName;
+    private final String listedFolderId;
+    private final String listedFolderName;
 
     public String getId() {
         return id;
@@ -126,6 +139,23 @@ public class GoogleDriveFileInfo implements ListableEntity {
         return webContentLink;
     }
 
+    public String getParentFolderId() {
+        return parentFolderId;
+    }
+
+    public String getParentFolderName() {
+        return parentFolderName;
+    }
+
+    public String getListedFolderId() {
+        return listedFolderId;
+    }
+
+    public String getListedFolderName() {
+        return listedFolderName;
+    }
+
+    @Override
     public Record toRecord() {
         return new MapRecord(SCHEMA, toMap());
     }
@@ -146,6 +176,10 @@ public class GoogleDriveFileInfo implements ListableEntity {
         values.put(LAST_MODIFYING_USER, getLastModifyingUser());
         values.put(WEB_VIEW_LINK, getWebViewLink());
         values.put(WEB_CONTENT_LINK, getWebContentLink());
+        values.put(PARENT_FOLDER_ID, getParentFolderId());
+        values.put(PARENT_FOLDER_NAME, getParentFolderName());
+        values.put(LISTED_FOLDER_ID, getListedFolderId());
+        values.put(LISTED_FOLDER_NAME, getListedFolderName());
 
         return values;
     }
@@ -176,6 +210,10 @@ public class GoogleDriveFileInfo implements ListableEntity {
         private String lastModifyingUser;
         private String webViewLink;
         private String webContentLink;
+        private String parentFolderId;
+        private String parentFolderName;
+        private String listedFolderId;
+        private String listedFolderName;
 
         public Builder id(String id) {
             this.id = id;
@@ -237,6 +275,26 @@ public class GoogleDriveFileInfo implements ListableEntity {
             return this;
         }
 
+        public Builder parentFolderId(String parentFolderId) {
+            this.parentFolderId = parentFolderId;
+            return this;
+        }
+
+        public Builder parentFolderName(String parentFolderName) {
+            this.parentFolderName = parentFolderName;
+            return this;
+        }
+
+        public Builder listedFolderId(String listedFolderId) {
+            this.listedFolderId = listedFolderId;
+            return this;
+        }
+
+        public Builder listedFolderName(String listedFolderName) {
+            this.listedFolderName = listedFolderName;
+            return this;
+        }
+
         public GoogleDriveFileInfo build() {
             return new GoogleDriveFileInfo(this);
         }
@@ -286,6 +344,10 @@ public class GoogleDriveFileInfo implements ListableEntity {
         this.lastModifyingUser = builder.lastModifyingUser;
         this.webViewLink = builder.webViewLink;
         this.webContentLink = builder.webContentLink;
+        this.parentFolderId = builder.parentFolderId;
+        this.parentFolderName = builder.parentFolderName;
+        this.listedFolderId = builder.listedFolderId;
+        this.listedFolderName = builder.listedFolderName;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -300,15 +300,16 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
                 .setFields("name, driveId")
                 .execute();
 
-        if (folder.getDriveId() == null) {
-            return folder.getName();
-        } else {
+        if (folderId.equals(folder.getDriveId())) {
+            // if folderId points to a Shared Drive root, files() returns "Drive" for the name and drives() needs to be used to get the real name
             return driveService
                     .drives()
                     .get(folderId)
                     .setFields("name")
                     .execute()
                     .getName();
+        } else {
+            return folder.getName();
         }
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -74,11 +74,17 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
@@ -116,7 +122,11 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIE
         @WritesAttribute(attribute = OWNER, description = OWNER_DESC),
         @WritesAttribute(attribute = LAST_MODIFYING_USER, description = LAST_MODIFYING_USER_DESC),
         @WritesAttribute(attribute = WEB_VIEW_LINK, description = WEB_VIEW_LINK_DESC),
-        @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC)})
+        @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC),
+        @WritesAttribute(attribute = PARENT_FOLDER_ID, description = PARENT_FOLDER_ID_DESC),
+        @WritesAttribute(attribute = PARENT_FOLDER_NAME, description = PARENT_FOLDER_NAME_DESC),
+        @WritesAttribute(attribute = LISTED_FOLDER_ID, description = WEB_CONTENT_LINK_DESC),
+        @WritesAttribute(attribute = LISTED_FOLDER_NAME, description = WEB_CONTENT_LINK_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already." +
         " What exactly needs to be stored depends on the 'Listing Strategy'." +
         " State is stored across the cluster so that this Processor can be run on Primary Node only and if a new Primary Node is selected, the new node can pick up" +
@@ -191,6 +201,9 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
     private volatile Drive driveService;
 
+    private volatile String listedFolderId;
+    private volatile String listedFolderName;
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return PROPERTIES;
@@ -215,6 +228,9 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
         HttpTransport httpTransport = new ProxyAwareTransportFactory(proxyConfiguration).create();
 
         driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE, DriveScopes.DRIVE_METADATA_READONLY);
+
+        listedFolderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions().getValue();
+        listedFolderName = getFolderName(listedFolderId);
     }
 
     @Override
@@ -257,7 +273,6 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
     ) throws IOException {
         final List<GoogleDriveFileInfo> listing = new ArrayList<>();
 
-        final String folderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions().getValue();
         final Boolean recursive = context.getProperty(RECURSIVE_SEARCH).asBoolean();
         final Long minAge = context.getProperty(MIN_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
 
@@ -285,9 +300,9 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         final String queryTemplate = queryTemplateBuilder.toString();
 
-        final String folderPath = urlEncode(getFolderName(folderId));
+        final String listedFolderPath = urlEncode(listedFolderName);
 
-        queryFolder(folderId, folderPath, queryTemplate, recursive, listing);
+        queryFolder(listedFolderId, listedFolderName, listedFolderPath, queryTemplate, recursive, listing);
 
         return listing;
     }
@@ -320,6 +335,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
     private void queryFolder(
             final String folderId,
+            final String folderName,
             final String folderPath,
             final String queryTemplate,
             final boolean recursive,
@@ -351,7 +367,11 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
                             .lastModifyingUser(Optional.ofNullable(file.getLastModifyingUser())
                                     .map(User::getDisplayName).orElse(null))
                             .webViewLink(file.getWebViewLink())
-                            .webContentLink(file.getWebContentLink());
+                            .webContentLink(file.getWebContentLink())
+                            .parentFolderId(folderId)
+                            .parentFolderName(folderName)
+                            .listedFolderId(listedFolderId)
+                            .listedFolderName(listedFolderName);
 
                     listing.add(builder.build());
                 }
@@ -362,7 +382,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         for (final File subfolder : subfolders) {
             final String subfolderPath = folderPath + "/" + urlEncode(subfolder.getName());
-            queryFolder(subfolder.getId(), subfolderPath, queryTemplate, true, listing);
+            queryFolder(subfolder.getId(), subfolder.getName(), subfolderPath, queryTemplate, true, listing);
         }
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -17,11 +17,11 @@
 package org.apache.nifi.processors.gcp.drive;
 
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.FileList;
+import com.google.api.services.drive.model.User;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.PrimaryNodeOnly;
@@ -51,6 +51,9 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.serialization.record.RecordSchema;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -59,22 +62,35 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_CONTENT_LINK;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_CONTENT_LINK_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIEW_LINK;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIEW_LINK_DESC;
 
 @PrimaryNodeOnly
 @TriggerSerially
@@ -93,7 +109,14 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTA
         @WritesAttribute(attribute = "mime.type", description = MIME_TYPE_DESC),
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = SIZE_AVAILABLE, description = SIZE_AVAILABLE_DESC),
-        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC)})
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
+        @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
+        @WritesAttribute(attribute = PATH, description = PATH_DESC),
+        @WritesAttribute(attribute = OWNER, description = OWNER_DESC),
+        @WritesAttribute(attribute = LAST_MODIFYING_USER, description = LAST_MODIFYING_USER_DESC),
+        @WritesAttribute(attribute = WEB_VIEW_LINK, description = WEB_VIEW_LINK_DESC),
+        @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already." +
         " What exactly needs to be stored depends on the 'Listing Strategy'." +
         " State is stored across the cluster so that this Processor can be run on Primary Node only and if a new Primary Node is selected, the new node can pick up" +
@@ -182,14 +205,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             final GoogleDriveFileInfo entity,
             final ProcessContext context
     ) {
-        final Map<String, String> attributes = new HashMap<>();
-
-        for (GoogleDriveFlowFileAttribute attribute : GoogleDriveFlowFileAttribute.values()) {
-            Optional.ofNullable(attribute.getValue(entity))
-                    .ifPresent(value -> attributes.put(attribute.getName(), value));
-        }
-
-        return attributes;
+        return entity.toAttributeMap();
     }
 
     @OnScheduled
@@ -198,7 +214,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         HttpTransport httpTransport = new ProxyAwareTransportFactory(proxyConfiguration).create();
 
-        driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE_METADATA_READONLY);
+        driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE, DriveScopes.DRIVE_METADATA_READONLY);
     }
 
     @Override
@@ -252,7 +268,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
         if (minTimestamp != null && minTimestamp > 0) {
             String formattedMinTimestamp = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.ofInstant(Instant.ofEpochMilli(minTimestamp), ZoneOffset.UTC));
 
-            queryTemplateBuilder.append(" and (mimeType != '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
+            queryTemplateBuilder.append(" and (mimeType = '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
             queryTemplateBuilder.append(" or modifiedTime >= '").append(formattedMinTimestamp).append("'");
             queryTemplateBuilder.append(" or createdTime >= '").append(formattedMinTimestamp).append( "'");
             queryTemplateBuilder.append(")");
@@ -261,7 +277,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             long maxTimestamp = System.currentTimeMillis() - minAge;
             String formattedMaxTimestamp = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.ofInstant(Instant.ofEpochMilli(maxTimestamp), ZoneOffset.UTC));
 
-            queryTemplateBuilder.append(" and (mimeType != '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
+            queryTemplateBuilder.append(" and (mimeType = '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
             queryTemplateBuilder.append(" or (modifiedTime < '").append(formattedMaxTimestamp).append("'");
             queryTemplateBuilder.append(" and createdTime < '").append(formattedMaxTimestamp).append("')");
             queryTemplateBuilder.append(")");
@@ -269,9 +285,31 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         final String queryTemplate = queryTemplateBuilder.toString();
 
-        queryFolder(driveService, folderId, queryTemplate, recursive, listing);
+        final String folderPath = urlEncode(getFolderName(folderId));
+
+        queryFolder(folderId, folderPath, queryTemplate, recursive, listing);
 
         return listing;
+    }
+
+    private String getFolderName(final String folderId) throws IOException {
+        final File folder = driveService
+                .files()
+                .get(folderId)
+                .setSupportsAllDrives(true)
+                .setFields("name, driveId")
+                .execute();
+
+        if (folder.getDriveId() == null) {
+            return folder.getName();
+        } else {
+            return driveService
+                    .drives()
+                    .get(folderId)
+                    .setFields("name")
+                    .execute()
+                    .getName();
+        }
     }
 
     @Override
@@ -280,13 +318,14 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
     }
 
     private void queryFolder(
-            final Drive driveService,
             final String folderId,
+            final String folderPath,
             final String queryTemplate,
             final boolean recursive,
             final List<GoogleDriveFileInfo> listing
     ) throws IOException {
-        final List<String> subFolderIds = new ArrayList<>();
+        final List<File> subfolders = new ArrayList<>();
+
         String pageToken = null;
         do {
             final FileList result = driveService.files()
@@ -295,23 +334,23 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
                     .setIncludeItemsFromAllDrives(true)
                     .setQ(String.format(queryTemplate, folderId))
                     .setPageToken(pageToken)
-                    .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType)")
+                    .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType, owners, lastModifyingUser, webViewLink, webContentLink)")
                     .execute();
 
             for (final File file : result.getFiles()) {
                 if (DRIVE_FOLDER_MIME_TYPE.equals(file.getMimeType())) {
                     if (recursive) {
-                        subFolderIds.add(file.getId());
+                        subfolders.add(file);
                     }
                 } else {
-                    GoogleDriveFileInfo.Builder builder = new GoogleDriveFileInfo.Builder()
-                            .id(file.getId())
-                            .fileName(file.getName())
-                            .size(file.getSize() != null ? file.getSize() : 0L)
-                            .sizeAvailable(file.getSize() != null)
-                            .createdTime(Optional.ofNullable(file.getCreatedTime()).map(DateTime::getValue).orElse(0L))
-                            .modifiedTime(Optional.ofNullable(file.getModifiedTime()).map(DateTime::getValue).orElse(0L))
-                            .mimeType(file.getMimeType());
+                    final GoogleDriveFileInfo.Builder builder = createGoogleDriveFileInfoBuilder(file)
+                            .path(folderPath)
+                            .owner(Optional.ofNullable(file.getOwners()).filter(owners -> !owners.isEmpty())
+                                    .map(owners -> owners.get(0)).map(User::getDisplayName).orElse(null))
+                            .lastModifyingUser(Optional.ofNullable(file.getLastModifyingUser())
+                                    .map(User::getDisplayName).orElse(null))
+                            .webViewLink(file.getWebViewLink())
+                            .webContentLink(file.getWebContentLink());
 
                     listing.add(builder.build());
                 }
@@ -319,8 +358,19 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
             pageToken = result.getNextPageToken();
         } while (pageToken != null);
-            for (final String subFolderId : subFolderIds) {
-                queryFolder(driveService, subFolderId, queryTemplate, true, listing);
-            }
+
+        for (final File subfolder : subfolders) {
+            final String subfolderPath = folderPath + "/" + urlEncode(subfolder.getName());
+            queryFolder(subfolder.getId(), subfolderPath, queryTemplate, true, listing);
+        }
+    }
+
+    private String urlEncode(final String str) {
+        try {
+            return URLEncoder.encode(str, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 is always supported, so this should never happen
+            throw new RuntimeException("UTF-8 not supported", e);
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -75,7 +75,9 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_NAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_NAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
@@ -87,6 +89,10 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_ID_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_NAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_NAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
@@ -125,8 +131,10 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIE
         @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC),
         @WritesAttribute(attribute = PARENT_FOLDER_ID, description = PARENT_FOLDER_ID_DESC),
         @WritesAttribute(attribute = PARENT_FOLDER_NAME, description = PARENT_FOLDER_NAME_DESC),
-        @WritesAttribute(attribute = LISTED_FOLDER_ID, description = WEB_CONTENT_LINK_DESC),
-        @WritesAttribute(attribute = LISTED_FOLDER_NAME, description = WEB_CONTENT_LINK_DESC)})
+        @WritesAttribute(attribute = LISTED_FOLDER_ID, description = LISTED_FOLDER_ID_DESC),
+        @WritesAttribute(attribute = LISTED_FOLDER_NAME, description = LISTED_FOLDER_NAME_DESC),
+        @WritesAttribute(attribute = SHARED_DRIVE_ID, description = SHARED_DRIVE_ID_DESC),
+        @WritesAttribute(attribute = SHARED_DRIVE_NAME, description = SHARED_DRIVE_NAME_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already." +
         " What exactly needs to be stored depends on the 'Listing Strategy'." +
         " State is stored across the cluster so that this Processor can be run on Primary Node only and if a new Primary Node is selected, the new node can pick up" +
@@ -201,9 +209,6 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
     private volatile Drive driveService;
 
-    private volatile String listedFolderId;
-    private volatile String listedFolderName;
-
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return PROPERTIES;
@@ -222,15 +227,12 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
     }
 
     @OnScheduled
-    public void onScheduled(final ProcessContext context) throws IOException {
+    public void onScheduled(final ProcessContext context) {
         final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(context);
 
         HttpTransport httpTransport = new ProxyAwareTransportFactory(proxyConfiguration).create();
 
         driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE, DriveScopes.DRIVE_METADATA_READONLY);
-
-        listedFolderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions().getValue();
-        listedFolderName = getFolderName(listedFolderId);
     }
 
     @Override
@@ -273,6 +275,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
     ) throws IOException {
         final List<GoogleDriveFileInfo> listing = new ArrayList<>();
 
+        final String folderId = context.getProperty(FOLDER_ID).evaluateAttributeExpressions().getValue();
         final Boolean recursive = context.getProperty(RECURSIVE_SEARCH).asBoolean();
         final Long minAge = context.getProperty(MIN_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
 
@@ -300,32 +303,12 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         final String queryTemplate = queryTemplateBuilder.toString();
 
-        final String listedFolderPath = urlEncode(listedFolderName);
+        final FolderDetails folderDetails = getFolderDetails(driveService, folderId);
+        final String folderPath = urlEncode(folderDetails.getFolderName());
 
-        queryFolder(listedFolderId, listedFolderName, listedFolderPath, queryTemplate, recursive, listing);
+        queryFolder(folderDetails.getFolderId(), folderDetails.getFolderName(), folderPath, queryTemplate, recursive, folderDetails, listing);
 
         return listing;
-    }
-
-    private String getFolderName(final String folderId) throws IOException {
-        final File folder = driveService
-                .files()
-                .get(folderId)
-                .setSupportsAllDrives(true)
-                .setFields("name, driveId")
-                .execute();
-
-        if (folderId.equals(folder.getDriveId())) {
-            // if folderId points to a Shared Drive root, files() returns "Drive" for the name and drives() needs to be used to get the real name
-            return driveService
-                    .drives()
-                    .get(folderId)
-                    .setFields("name")
-                    .execute()
-                    .getName();
-        } else {
-            return folder.getName();
-        }
     }
 
     @Override
@@ -339,6 +322,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             final String folderPath,
             final String queryTemplate,
             final boolean recursive,
+            final FolderDetails listedFolderDetails,
             final List<GoogleDriveFileInfo> listing
     ) throws IOException {
         final List<File> subfolders = new ArrayList<>();
@@ -370,8 +354,10 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
                             .webContentLink(file.getWebContentLink())
                             .parentFolderId(folderId)
                             .parentFolderName(folderName)
-                            .listedFolderId(listedFolderId)
-                            .listedFolderName(listedFolderName);
+                            .listedFolderId(listedFolderDetails.getFolderId())
+                            .listedFolderName(listedFolderDetails.getFolderName())
+                            .sharedDriveId(listedFolderDetails.getSharedDriveId())
+                            .sharedDriveName(listedFolderDetails.getSharedDriveName());
 
                     listing.add(builder.build());
                 }
@@ -382,7 +368,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         for (final File subfolder : subfolders) {
             final String subfolderPath = folderPath + "/" + urlEncode(subfolder.getName());
-            queryFolder(subfolder.getId(), subfolder.getName(), subfolderPath, queryTemplate, true, listing);
+            queryFolder(subfolder.getId(), subfolder.getName(), subfolderPath, queryTemplate, true, listedFolderDetails, listing);
         }
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -17,11 +17,11 @@
 package org.apache.nifi.processors.gcp.drive;
 
 import com.google.api.client.http.HttpTransport;
+import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.FileList;
-import com.google.api.services.drive.model.User;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.PrimaryNodeOnly;
@@ -51,9 +51,6 @@ import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.apache.nifi.serialization.record.RecordSchema;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -62,35 +59,22 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_CONTENT_LINK;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_CONTENT_LINK_DESC;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIEW_LINK;
-import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIEW_LINK_DESC;
 
 @PrimaryNodeOnly
 @TriggerSerially
@@ -109,14 +93,7 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.WEB_VIE
         @WritesAttribute(attribute = "mime.type", description = MIME_TYPE_DESC),
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = SIZE_AVAILABLE, description = SIZE_AVAILABLE_DESC),
-        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
-        @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
-        @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
-        @WritesAttribute(attribute = PATH, description = PATH_DESC),
-        @WritesAttribute(attribute = OWNER, description = OWNER_DESC),
-        @WritesAttribute(attribute = LAST_MODIFYING_USER, description = LAST_MODIFYING_USER_DESC),
-        @WritesAttribute(attribute = WEB_VIEW_LINK, description = WEB_VIEW_LINK_DESC),
-        @WritesAttribute(attribute = WEB_CONTENT_LINK, description = WEB_CONTENT_LINK_DESC)})
+        @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC)})
 @Stateful(scopes = {Scope.CLUSTER}, description = "The processor stores necessary data to be able to keep track what files have been listed already." +
         " What exactly needs to be stored depends on the 'Listing Strategy'." +
         " State is stored across the cluster so that this Processor can be run on Primary Node only and if a new Primary Node is selected, the new node can pick up" +
@@ -205,7 +182,14 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             final GoogleDriveFileInfo entity,
             final ProcessContext context
     ) {
-        return entity.toAttributeMap();
+        final Map<String, String> attributes = new HashMap<>();
+
+        for (GoogleDriveFlowFileAttribute attribute : GoogleDriveFlowFileAttribute.values()) {
+            Optional.ofNullable(attribute.getValue(entity))
+                    .ifPresent(value -> attributes.put(attribute.getName(), value));
+        }
+
+        return attributes;
     }
 
     @OnScheduled
@@ -214,7 +198,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         HttpTransport httpTransport = new ProxyAwareTransportFactory(proxyConfiguration).create();
 
-        driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE, DriveScopes.DRIVE_METADATA_READONLY);
+        driveService = createDriveService(context, httpTransport, DriveScopes.DRIVE_METADATA_READONLY);
     }
 
     @Override
@@ -268,7 +252,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
         if (minTimestamp != null && minTimestamp > 0) {
             String formattedMinTimestamp = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.ofInstant(Instant.ofEpochMilli(minTimestamp), ZoneOffset.UTC));
 
-            queryTemplateBuilder.append(" and (mimeType = '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
+            queryTemplateBuilder.append(" and (mimeType != '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
             queryTemplateBuilder.append(" or modifiedTime >= '").append(formattedMinTimestamp).append("'");
             queryTemplateBuilder.append(" or createdTime >= '").append(formattedMinTimestamp).append( "'");
             queryTemplateBuilder.append(")");
@@ -277,7 +261,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             long maxTimestamp = System.currentTimeMillis() - minAge;
             String formattedMaxTimestamp = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.ofInstant(Instant.ofEpochMilli(maxTimestamp), ZoneOffset.UTC));
 
-            queryTemplateBuilder.append(" and (mimeType = '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
+            queryTemplateBuilder.append(" and (mimeType != '").append(DRIVE_FOLDER_MIME_TYPE).append("'");
             queryTemplateBuilder.append(" or (modifiedTime < '").append(formattedMaxTimestamp).append("'");
             queryTemplateBuilder.append(" and createdTime < '").append(formattedMaxTimestamp).append("')");
             queryTemplateBuilder.append(")");
@@ -285,32 +269,9 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
         final String queryTemplate = queryTemplateBuilder.toString();
 
-        final String folderPath = urlEncode(getFolderName(folderId));
-
-        queryFolder(folderId, folderPath, queryTemplate, recursive, listing);
+        queryFolder(driveService, folderId, queryTemplate, recursive, listing);
 
         return listing;
-    }
-
-    private String getFolderName(final String folderId) throws IOException {
-        final File folder = driveService
-                .files()
-                .get(folderId)
-                .setSupportsAllDrives(true)
-                .setFields("name, driveId")
-                .execute();
-
-        if (folderId.equals(folder.getDriveId())) {
-            // if folderId points to a Shared Drive root, files() returns "Drive" for the name and drives() needs to be used to get the real name
-            return driveService
-                    .drives()
-                    .get(folderId)
-                    .setFields("name")
-                    .execute()
-                    .getName();
-        } else {
-            return folder.getName();
-        }
     }
 
     @Override
@@ -319,14 +280,13 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
     }
 
     private void queryFolder(
+            final Drive driveService,
             final String folderId,
-            final String folderPath,
             final String queryTemplate,
             final boolean recursive,
             final List<GoogleDriveFileInfo> listing
     ) throws IOException {
-        final List<File> subfolders = new ArrayList<>();
-
+        final List<String> subFolderIds = new ArrayList<>();
         String pageToken = null;
         do {
             final FileList result = driveService.files()
@@ -335,23 +295,23 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
                     .setIncludeItemsFromAllDrives(true)
                     .setQ(String.format(queryTemplate, folderId))
                     .setPageToken(pageToken)
-                    .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType, owners, lastModifyingUser, webViewLink, webContentLink)")
+                    .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType)")
                     .execute();
 
             for (final File file : result.getFiles()) {
                 if (DRIVE_FOLDER_MIME_TYPE.equals(file.getMimeType())) {
                     if (recursive) {
-                        subfolders.add(file);
+                        subFolderIds.add(file.getId());
                     }
                 } else {
-                    final GoogleDriveFileInfo.Builder builder = createGoogleDriveFileInfoBuilder(file)
-                            .path(folderPath)
-                            .owner(Optional.ofNullable(file.getOwners()).filter(owners -> !owners.isEmpty())
-                                    .map(owners -> owners.get(0)).map(User::getDisplayName).orElse(null))
-                            .lastModifyingUser(Optional.ofNullable(file.getLastModifyingUser())
-                                    .map(User::getDisplayName).orElse(null))
-                            .webViewLink(file.getWebViewLink())
-                            .webContentLink(file.getWebContentLink());
+                    GoogleDriveFileInfo.Builder builder = new GoogleDriveFileInfo.Builder()
+                            .id(file.getId())
+                            .fileName(file.getName())
+                            .size(file.getSize() != null ? file.getSize() : 0L)
+                            .sizeAvailable(file.getSize() != null)
+                            .createdTime(Optional.ofNullable(file.getCreatedTime()).map(DateTime::getValue).orElse(0L))
+                            .modifiedTime(Optional.ofNullable(file.getModifiedTime()).map(DateTime::getValue).orElse(0L))
+                            .mimeType(file.getMimeType());
 
                     listing.add(builder.build());
                 }
@@ -359,19 +319,8 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
             pageToken = result.getNextPageToken();
         } while (pageToken != null);
-
-        for (final File subfolder : subfolders) {
-            final String subfolderPath = folderPath + "/" + urlEncode(subfolder.getName());
-            queryFolder(subfolder.getId(), subfolderPath, queryTemplate, true, listing);
-        }
-    }
-
-    private String urlEncode(final String str) {
-        try {
-            return URLEncoder.encode(str, StandardCharsets.UTF_8.toString());
-        } catch (UnsupportedEncodingException e) {
-            // UTF-8 is always supported, so this should never happen
-            throw new RuntimeException("UTF-8 not supported", e);
-        }
+            for (final String subFolderId : subFolderIds) {
+                queryFolder(driveService, subFolderId, queryTemplate, true, listing);
+            }
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/AbstractGCPubSubProcessor.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/AbstractGCPubSubProcessor.java
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.apache.nifi.processors.gcp.util.GoogleUtils.GOOGLE_CLOUD_PLATFORM_SCOPE;
+import static org.apache.nifi.processors.gcp.util.GoogleUtils.GOOGLE_CLOUD_PUBSUB_SCOPE;
 
 public abstract class AbstractGCPubSubProcessor extends AbstractGCPProcessor implements VerifiableProcessor {
 
@@ -132,7 +132,7 @@ public abstract class AbstractGCPubSubProcessor extends AbstractGCPProcessor imp
 
     @Override
     protected GoogleCredentials getGoogleCredentials(ProcessContext context) {
-        return super.getGoogleCredentials(context).createScoped(GOOGLE_CLOUD_PLATFORM_SCOPE);
+        return super.getGoogleCredentials(context).createScoped(GOOGLE_CLOUD_PUBSUB_SCOPE);
     }
 
     protected TransportChannelProvider getTransportChannelProvider(ProcessContext context) {

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/util/GoogleUtils.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/util/GoogleUtils.java
@@ -22,7 +22,8 @@ import org.apache.nifi.gcp.credentials.service.GCPCredentialsService;
 public class GoogleUtils {
 
     public static final String GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
-
+    public static final String GOOGLE_CLOUD_PUBSUB_SCOPE = "https://www.googleapis.com/auth/pubsub";
+    public static final String GOOGLE_CLOUD_BIGQUERY_SCOPE = "https://www.googleapis.com/auth/bigquery";
     /**
      * Links to the {@link GCPCredentialsService} which provides credentials for this particular processor.
      */

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.processors.gcp.drive;
 
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,9 +46,7 @@ public class AbstractGoogleDriveTest {
     public static final String CONTENT = "1234567890";
     public static final String TEST_FILENAME = "testFile";
     public static final String TEST_FILE_ID = "fileId";
-    public static final String SUBFOLDER_NAME = "subFolderName";
     public static final String SHARED_FOLDER_ID = "sharedFolderId";
-    public static final String SUBFOLDER_ID = "subFolderId";
     public static final long TEST_SIZE = 42;
     public static final long CREATED_TIME = 1659707000;
     public static final long MODIFIED_TIME = 1659708000;
@@ -98,18 +95,12 @@ public class AbstractGoogleDriveTest {
     }
 
     protected File createFile() {
-        return createFile(TEST_FILE_ID, TEST_FILENAME, SUBFOLDER_ID, TEXT_TYPE);
-    }
-
-    protected File createFile(String id, String name, String parentId, String mimeType) {
-        File file = new File();
-        file.setId(id);
-        file.setName(name);
-        file.setParents(singletonList(parentId));
-        file.setCreatedTime(new DateTime(CREATED_TIME));
-        file.setModifiedTime(new DateTime(MODIFIED_TIME));
-        file.setSize(TEST_SIZE);
-        file.setMimeType(mimeType);
-        return file;
+        return new File()
+                .setId(TEST_FILE_ID)
+                .setName(TEST_FILENAME)
+                .setCreatedTime(new DateTime(CREATED_TIME))
+                .setModifiedTime(new DateTime(MODIFIED_TIME))
+                .setSize(TEST_SIZE)
+                .setMimeType(TEXT_TYPE);
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -104,7 +104,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
                 .execute()).thenReturn(createFile());
     }
 
@@ -118,7 +118,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
                 .execute()).thenReturn(createFile());
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.processors.gcp.drive;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpTransport;
@@ -26,6 +28,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.google.api.services.drive.model.File;
+import com.google.api.services.drive.model.User;
+import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
@@ -33,10 +39,22 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
+
+    private static final String TEST_OWNER = "user1";
+    private static final String TEST_LAST_MODIFYING_USER = "user2";
+    private static final String TEST_WEB_VIEW_LINK = "http://web.view";
+    private static final String TEST_WEB_CONTENT_LINK = "http://web.content";
+    private static final String TEST_PARENT_FOLDER_ID = "folder-id";
+    private static final String TEST_PARENT_FOLDER_NAME = "folder-name";
+    private static final String TEST_SHARED_DRIVE_ID = "drive-id";
+    private static final String TEST_SHARED_DRIVE_NAME = "drive-name";
 
     @BeforeEach
     protected void setUp() throws Exception {
@@ -52,10 +70,12 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
     }
 
     @Test
-    void testFileFetchFileNameFromProperty() throws IOException {
+    void testFileFetchFileIdFromProperty() throws IOException {
         testRunner.setProperty(FetchGoogleDrive.FILE_ID, TEST_FILE_ID);
 
-        mockFileDownload(TEST_FILE_ID);
+        mockGetFileMetaDataExtended(TEST_FILE_ID);
+        mockFileDownloadSuccess(TEST_FILE_ID);
+
         runWithFlowFile();
 
         testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_SUCCESS, 1);
@@ -64,26 +84,88 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
     }
 
     @Test
-    void testFetchFileNameFromFlowFileAttribute() throws Exception {
+    void testFetchFileIdFromFlowFileAttribute() throws Exception {
         final MockFlowFile mockFlowFile = new MockFlowFile(0);
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(GoogleDriveAttributes.ID, TEST_FILE_ID);
         mockFlowFile.putAttributes(attributes);
 
-        mockFileDownload(TEST_FILE_ID);
+        mockGetFileMetaDataExtended(TEST_FILE_ID);
+        mockFileDownloadSuccess(TEST_FILE_ID);
 
-        testRunner.enqueue(mockFlowFile);
-        testRunner.run();
+        runWithFlowFile(mockFlowFile);
 
         testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_SUCCESS, 1);
         assertFlowFileAttributes(FetchGoogleDrive.REL_SUCCESS);
         assertProvenanceEvent(ProvenanceEventType.FETCH);
     }
 
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {TEST_SHARED_DRIVE_ID})
+    void testFileFetchByListResult(String driveId) throws IOException {
+        final MockFlowFile mockFlowFile = new MockFlowFile(0);
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(GoogleDriveAttributes.ID, TEST_FILE_ID);
+        attributes.put(GoogleDriveAttributes.LISTED_FOLDER_ID, TEST_PARENT_FOLDER_ID);
+        attributes.put(GoogleDriveAttributes.OWNER, TEST_OWNER);
+        attributes.put(GoogleDriveAttributes.LAST_MODIFYING_USER, TEST_LAST_MODIFYING_USER);
+        attributes.put(GoogleDriveAttributes.WEB_VIEW_LINK, TEST_WEB_VIEW_LINK);
+        attributes.put(GoogleDriveAttributes.WEB_CONTENT_LINK, TEST_WEB_CONTENT_LINK);
+        attributes.put(GoogleDriveAttributes.PARENT_FOLDER_ID, TEST_PARENT_FOLDER_ID);
+        attributes.put(GoogleDriveAttributes.PARENT_FOLDER_NAME, TEST_PARENT_FOLDER_NAME);
+        attributes.put(GoogleDriveAttributes.SHARED_DRIVE_ID, driveId);
+        attributes.put(GoogleDriveAttributes.SHARED_DRIVE_NAME, driveId != null ? TEST_SHARED_DRIVE_NAME : null);
+        mockFlowFile.putAttributes(attributes);
+
+        mockGetFileMetaDataBasic(TEST_FILE_ID);
+        mockFileDownloadSuccess(TEST_FILE_ID);
+
+        runWithFlowFile(mockFlowFile);
+
+        assertFlowFile(driveId);
+        assertProvenanceEvent(ProvenanceEventType.FETCH);
+
+        verify(mockDriverService, never()).drives();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {TEST_SHARED_DRIVE_ID})
+    void testFileFetchByIdOnly(String driveId) throws IOException {
+        testRunner.setProperty(FetchGoogleDrive.FILE_ID, TEST_FILE_ID);
+
+        mockGetFileMetaDataExtended(TEST_FILE_ID, driveId);
+        mockFileDownloadSuccess(TEST_FILE_ID);
+
+        runWithFlowFile();
+
+        assertFlowFile(driveId);
+        assertProvenanceEvent(ProvenanceEventType.FETCH);
+    }
+
+    private void assertFlowFile(String driveId) {
+        testRunner.assertAllFlowFilesTransferred(FetchGoogleDrive.REL_SUCCESS, 1);
+
+        assertFlowFileAttributes(FetchGoogleDrive.REL_SUCCESS);
+
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchGoogleDrive.REL_SUCCESS).getFirst();
+
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.OWNER, TEST_OWNER);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.LAST_MODIFYING_USER, TEST_LAST_MODIFYING_USER);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.WEB_VIEW_LINK, TEST_WEB_VIEW_LINK);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.WEB_CONTENT_LINK, TEST_WEB_CONTENT_LINK);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.PARENT_FOLDER_ID, TEST_PARENT_FOLDER_ID);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.PARENT_FOLDER_NAME, TEST_PARENT_FOLDER_NAME);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.SHARED_DRIVE_ID, driveId);
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.SHARED_DRIVE_NAME, driveId != null ? TEST_SHARED_DRIVE_NAME : null);
+    }
+
     @Test
     void testFileFetchError() throws Exception {
         testRunner.setProperty(FetchGoogleDrive.FILE_ID, TEST_FILE_ID);
 
+        mockGetFileMetaDataExtended(TEST_FILE_ID);
         mockFileDownloadError(TEST_FILE_ID, new RuntimeException("Error during download"));
 
         runWithFlowFile();
@@ -95,17 +177,12 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         assertNoProvenanceEvent();
     }
 
-    private void mockFileDownload(String fileId) throws IOException {
+    private void mockFileDownloadSuccess(String fileId) throws IOException {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .executeMediaAsInputStream()).thenReturn(new ByteArrayInputStream(CONTENT.getBytes(UTF_8)));
-
-        when(mockDriverService.files()
-                .get(fileId)
-                .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks, owners, lastModifyingUser, webViewLink, webContentLink")
-                .execute()).thenReturn(createFile());
+                .executeMediaAsInputStream())
+                .thenReturn(new ByteArrayInputStream(CONTENT.getBytes(UTF_8)));
     }
 
     private void mockFileDownloadError(String fileId, Exception exception) throws IOException {
@@ -114,16 +191,60 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
                 .setSupportsAllDrives(true)
                 .executeMediaAsInputStream())
                 .thenThrow(exception);
+    }
 
+    private void mockGetFileMetaDataBasic(String fileId) throws IOException {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks, owners, lastModifyingUser, webViewLink, webContentLink")
-                .execute()).thenReturn(createFile());
+                .setFields(FetchGoogleDrive.FILE_METADATA_FIELDS_BASIC)
+                .execute())
+                .thenReturn(createFile());
+    }
+
+    private void mockGetFileMetaDataExtended(String fileId) throws IOException {
+        mockGetFileMetaDataExtended(fileId, null);
+    }
+
+    private void mockGetFileMetaDataExtended(String fileId, String driveId) throws IOException {
+        when(mockDriverService.files()
+                .get(fileId)
+                .setSupportsAllDrives(true)
+                .setFields(FetchGoogleDrive.FILE_METADATA_FIELDS_EXTENDED)
+                .execute())
+                .thenReturn(createFile()
+                        .setOwners(List.of(new User().setDisplayName(TEST_OWNER)))
+                        .setLastModifyingUser(new User().setDisplayName(TEST_LAST_MODIFYING_USER))
+                        .setWebViewLink(TEST_WEB_VIEW_LINK)
+                        .setWebContentLink(TEST_WEB_CONTENT_LINK)
+                        .setParents(List.of(TEST_PARENT_FOLDER_ID)));
+
+        when(mockDriverService.files()
+                .get(TEST_PARENT_FOLDER_ID)
+                .setSupportsAllDrives(true)
+                .setFields("name, driveId")
+                .execute()
+        ).thenReturn(new File()
+                .setName(TEST_PARENT_FOLDER_NAME)
+                .setDriveId(driveId)
+        );
+
+        if (driveId != null) {
+            when(mockDriverService.drives()
+                    .get(driveId)
+                    .setFields("name")
+                    .execute()
+                    .getName()
+            ).thenReturn(TEST_SHARED_DRIVE_NAME);
+        }
     }
 
     private void runWithFlowFile() {
-        testRunner.enqueue(new MockFlowFile(0));
+        runWithFlowFile(new MockFlowFile(0));
+    }
+
+    private void runWithFlowFile(FlowFile flowFile) {
+        testRunner.enqueue(flowFile);
         testRunner.run();
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -104,7 +104,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks, owners, lastModifyingUser, webViewLink, webContentLink")
                 .execute()).thenReturn(createFile());
     }
 
@@ -118,7 +118,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks, owners, lastModifyingUser, webViewLink, webContentLink")
                 .execute()).thenReturn(createFile());
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -149,7 +149,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
 
         assertFlowFileAttributes(FetchGoogleDrive.REL_SUCCESS);
 
-        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchGoogleDrive.REL_SUCCESS).getFirst();
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchGoogleDrive.REL_SUCCESS).get(0);
 
         flowFile.assertAttributeEquals(GoogleDriveAttributes.OWNER, TEST_OWNER);
         flowFile.assertAttributeEquals(GoogleDriveAttributes.LAST_MODIFYING_USER, TEST_LAST_MODIFYING_USER);

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -104,7 +104,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, mimeType, size, exportLinks")
                 .execute()).thenReturn(createFile());
     }
 
@@ -118,7 +118,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, mimeType, size, exportLinks")
                 .execute()).thenReturn(createFile());
     }
 

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -47,9 +47,6 @@ public class ListGoogleDriveSimpleTest {
 
     private String listingModeAsString = "EXECUTION";
 
-    String folderId = "folder_id";
-    String folderName = "folder_name";
-
     @BeforeEach
     void setUp() throws Exception {
         mockProcessContext = mock(ProcessContext.class, RETURNS_DEEP_STUBS);
@@ -77,6 +74,9 @@ public class ListGoogleDriveSimpleTest {
         // GIVEN
         Long minTimestamp = 0L;
         listingModeAsString = "EXECUTION";
+
+        String folderId = "folder_id";
+        String folderName = "folder_name";
 
         String id = "id_1";
         String filename = "file_name_1";

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -20,6 +20,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
+import com.google.api.services.drive.model.User;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.EqualsWrapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
@@ -43,6 +46,9 @@ public class ListGoogleDriveSimpleTest {
     private Drive mockDriverService;
 
     private String listingModeAsString = "EXECUTION";
+
+    String folderId = "folder_id";
+    String folderName = "folder_name";
 
     @BeforeEach
     void setUp() throws Exception {
@@ -78,14 +84,32 @@ public class ListGoogleDriveSimpleTest {
         long createdTime = 123456L;
         long modifiedTime = 234567L;
         String mimeType = "mime_type_1";
+        String owner = "user1";
+        String lastModifyingUser = "user2";
+        String webViewLink = "http://web.view";
+        String webContentLink = "http://web.content";
+
+        when(mockProcessContext.getProperty(ListGoogleDrive.FOLDER_ID)
+                .evaluateAttributeExpressions()
+                .getValue()
+        ).thenReturn(folderId);
+
+        when(mockDriverService.files()
+                .get(folderId)
+                .setSupportsAllDrives(true)
+                .setFields("name, driveId")
+                .execute()
+        ).thenReturn(new File()
+                .setName(folderName)
+        );
 
         when(mockDriverService.files()
                 .list()
                 .setSupportsAllDrives(true)
                 .setIncludeItemsFromAllDrives(true)
-                .setQ("('null' in parents) and (mimeType != 'application/vnd.google-apps.shortcut') and trashed = false")
+                .setQ("('" + folderId + "' in parents) and (mimeType != 'application/vnd.google-apps.shortcut') and trashed = false")
                 .setPageToken(null)
-                .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType)")
+                .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType, owners, lastModifyingUser, webViewLink, webContentLink)")
                 .execute()
                 .getFiles()
         ).thenReturn(singletonList(
@@ -95,7 +119,11 @@ public class ListGoogleDriveSimpleTest {
                         size,
                         new DateTime(createdTime),
                         new DateTime(modifiedTime),
-                        mimeType
+                        mimeType,
+                        owner,
+                        lastModifyingUser,
+                        webViewLink,
+                        webContentLink
                 )
         ));
 
@@ -104,9 +132,15 @@ public class ListGoogleDriveSimpleTest {
                         .id(id)
                         .fileName(filename)
                         .size(size)
+                        .sizeAvailable(true)
                         .createdTime(createdTime)
                         .modifiedTime(modifiedTime)
                         .mimeType(mimeType)
+                        .path(folderName)
+                        .owner(owner)
+                        .lastModifyingUser(lastModifyingUser)
+                        .webViewLink(webViewLink)
+                        .webContentLink(webContentLink)
                         .build()
         );
 
@@ -119,10 +153,16 @@ public class ListGoogleDriveSimpleTest {
                 GoogleDriveFileInfo::getIdentifier,
                 GoogleDriveFileInfo::getName,
                 GoogleDriveFileInfo::getSize,
+                GoogleDriveFileInfo::isSizeAvailable,
                 GoogleDriveFileInfo::getTimestamp,
                 GoogleDriveFileInfo::getCreatedTime,
                 GoogleDriveFileInfo::getModifiedTime,
-                GoogleDriveFileInfo::getMimeType
+                GoogleDriveFileInfo::getMimeType,
+                GoogleDriveFileInfo::getPath,
+                GoogleDriveFileInfo::getOwner,
+                GoogleDriveFileInfo::getLastModifyingUser,
+                GoogleDriveFileInfo::getWebViewLink,
+                GoogleDriveFileInfo::getWebContentLink
         );
 
         List<EqualsWrapper<GoogleDriveFileInfo>> expectedWrapper = wrapList(expected, propertyProviders);
@@ -137,8 +177,11 @@ public class ListGoogleDriveSimpleTest {
             Long size,
             DateTime createdTime,
             DateTime modifiedTime,
-            String mimeType
-    ) {
+            String mimeType,
+            String owner,
+            String lastModifyingUser,
+            String webViewLink,
+            String webContentLink) {
         File file = new File();
 
         file
@@ -147,7 +190,11 @@ public class ListGoogleDriveSimpleTest {
                 .setMimeType(mimeType)
                 .setCreatedTime(createdTime)
                 .setModifiedTime(modifiedTime)
-                .setSize(size);
+                .setSize(size)
+                .setOwners(Collections.unmodifiableList(Arrays.asList(new User().setDisplayName(owner))))
+                .setLastModifyingUser(new User().setDisplayName(lastModifyingUser))
+                .setWebViewLink(webViewLink)
+                .setWebContentLink(webContentLink);
 
         return file;
     }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -65,8 +65,6 @@ public class ListGoogleDriveSimpleTest {
                 return mockDriverService;
             }
         };
-
-        testSubject.onScheduled(mockProcessContext);
     }
 
     @Test
@@ -141,8 +139,14 @@ public class ListGoogleDriveSimpleTest {
                         .lastModifyingUser(lastModifyingUser)
                         .webViewLink(webViewLink)
                         .webContentLink(webContentLink)
+                        .parentFolderId(folderId)
+                        .parentFolderName(folderName)
+                        .listedFolderId(folderId)
+                        .listedFolderName(folderName)
                         .build()
         );
+
+        testSubject.onScheduled(mockProcessContext);
 
         // WHEN
         List<GoogleDriveFileInfo> actual = testSubject.performListing(mockProcessContext, minTimestamp, null);
@@ -162,7 +166,11 @@ public class ListGoogleDriveSimpleTest {
                 GoogleDriveFileInfo::getOwner,
                 GoogleDriveFileInfo::getLastModifyingUser,
                 GoogleDriveFileInfo::getWebViewLink,
-                GoogleDriveFileInfo::getWebContentLink
+                GoogleDriveFileInfo::getWebContentLink,
+                GoogleDriveFileInfo::getParentFolderId,
+                GoogleDriveFileInfo::getParentFolderName,
+                GoogleDriveFileInfo::getListedFolderId,
+                GoogleDriveFileInfo::getListedFolderName
         );
 
         List<EqualsWrapper<GoogleDriveFileInfo>> expectedWrapper = wrapList(expected, propertyProviders);

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -24,7 +24,9 @@ import com.google.api.services.drive.model.User;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.EqualsWrapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.List;
@@ -67,14 +69,18 @@ public class ListGoogleDriveSimpleTest {
         };
     }
 
-    @Test
-    void testCreatedListableEntityContainsCorrectData() throws Exception {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"drive_id"})
+    void testCreatedListableEntityContainsCorrectData(String driveId) throws Exception {
         // GIVEN
         Long minTimestamp = 0L;
         listingModeAsString = "EXECUTION";
 
         String folderId = "folder_id";
         String folderName = "folder_name";
+
+        String driveName = driveId != null ? "drive_name" : null;
 
         String id = "id_1";
         String filename = "file_name_1";
@@ -99,7 +105,15 @@ public class ListGoogleDriveSimpleTest {
                 .execute()
         ).thenReturn(new File()
                 .setName(folderName)
+                .setDriveId(driveId)
         );
+
+        when(mockDriverService.drives()
+                .get(driveId)
+                .setFields("name")
+                .execute()
+                .getName()
+        ).thenReturn(driveName);
 
         when(mockDriverService.files()
                 .list()
@@ -143,6 +157,8 @@ public class ListGoogleDriveSimpleTest {
                         .parentFolderName(folderName)
                         .listedFolderId(folderId)
                         .listedFolderName(folderName)
+                        .sharedDriveId(driveId)
+                        .sharedDriveName(driveName)
                         .build()
         );
 
@@ -170,7 +186,9 @@ public class ListGoogleDriveSimpleTest {
                 GoogleDriveFileInfo::getParentFolderId,
                 GoogleDriveFileInfo::getParentFolderName,
                 GoogleDriveFileInfo::getListedFolderId,
-                GoogleDriveFileInfo::getListedFolderName
+                GoogleDriveFileInfo::getListedFolderName,
+                GoogleDriveFileInfo::getSharedDriveId,
+                GoogleDriveFileInfo::getSharedDriveName
         );
 
         List<EqualsWrapper<GoogleDriveFileInfo>> expectedWrapper = wrapList(expected, propertyProviders);

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -20,7 +20,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
-import com.google.api.services.drive.model.User;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.EqualsWrapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,8 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
@@ -46,9 +43,6 @@ public class ListGoogleDriveSimpleTest {
     private Drive mockDriverService;
 
     private String listingModeAsString = "EXECUTION";
-
-    String folderId = "folder_id";
-    String folderName = "folder_name";
 
     @BeforeEach
     void setUp() throws Exception {
@@ -84,32 +78,14 @@ public class ListGoogleDriveSimpleTest {
         long createdTime = 123456L;
         long modifiedTime = 234567L;
         String mimeType = "mime_type_1";
-        String owner = "user1";
-        String lastModifyingUser = "user2";
-        String webViewLink = "http://web.view";
-        String webContentLink = "http://web.content";
-
-        when(mockProcessContext.getProperty(ListGoogleDrive.FOLDER_ID)
-                .evaluateAttributeExpressions()
-                .getValue()
-        ).thenReturn(folderId);
-
-        when(mockDriverService.files()
-                .get(folderId)
-                .setSupportsAllDrives(true)
-                .setFields("name, driveId")
-                .execute()
-        ).thenReturn(new File()
-                .setName(folderName)
-        );
 
         when(mockDriverService.files()
                 .list()
                 .setSupportsAllDrives(true)
                 .setIncludeItemsFromAllDrives(true)
-                .setQ("('" + folderId + "' in parents) and (mimeType != 'application/vnd.google-apps.shortcut') and trashed = false")
+                .setQ("('null' in parents) and (mimeType != 'application/vnd.google-apps.shortcut') and trashed = false")
                 .setPageToken(null)
-                .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType, owners, lastModifyingUser, webViewLink, webContentLink)")
+                .setFields("nextPageToken, files(id, name, size, createdTime, modifiedTime, mimeType)")
                 .execute()
                 .getFiles()
         ).thenReturn(singletonList(
@@ -119,11 +95,7 @@ public class ListGoogleDriveSimpleTest {
                         size,
                         new DateTime(createdTime),
                         new DateTime(modifiedTime),
-                        mimeType,
-                        owner,
-                        lastModifyingUser,
-                        webViewLink,
-                        webContentLink
+                        mimeType
                 )
         ));
 
@@ -132,15 +104,9 @@ public class ListGoogleDriveSimpleTest {
                         .id(id)
                         .fileName(filename)
                         .size(size)
-                        .sizeAvailable(true)
                         .createdTime(createdTime)
                         .modifiedTime(modifiedTime)
                         .mimeType(mimeType)
-                        .path(folderName)
-                        .owner(owner)
-                        .lastModifyingUser(lastModifyingUser)
-                        .webViewLink(webViewLink)
-                        .webContentLink(webContentLink)
                         .build()
         );
 
@@ -153,16 +119,10 @@ public class ListGoogleDriveSimpleTest {
                 GoogleDriveFileInfo::getIdentifier,
                 GoogleDriveFileInfo::getName,
                 GoogleDriveFileInfo::getSize,
-                GoogleDriveFileInfo::isSizeAvailable,
                 GoogleDriveFileInfo::getTimestamp,
                 GoogleDriveFileInfo::getCreatedTime,
                 GoogleDriveFileInfo::getModifiedTime,
-                GoogleDriveFileInfo::getMimeType,
-                GoogleDriveFileInfo::getPath,
-                GoogleDriveFileInfo::getOwner,
-                GoogleDriveFileInfo::getLastModifyingUser,
-                GoogleDriveFileInfo::getWebViewLink,
-                GoogleDriveFileInfo::getWebContentLink
+                GoogleDriveFileInfo::getMimeType
         );
 
         List<EqualsWrapper<GoogleDriveFileInfo>> expectedWrapper = wrapList(expected, propertyProviders);
@@ -177,11 +137,8 @@ public class ListGoogleDriveSimpleTest {
             Long size,
             DateTime createdTime,
             DateTime modifiedTime,
-            String mimeType,
-            String owner,
-            String lastModifyingUser,
-            String webViewLink,
-            String webContentLink) {
+            String mimeType
+    ) {
         File file = new File();
 
         file
@@ -190,11 +147,7 @@ public class ListGoogleDriveSimpleTest {
                 .setMimeType(mimeType)
                 .setCreatedTime(createdTime)
                 .setModifiedTime(modifiedTime)
-                .setSize(size)
-                .setOwners(Collections.unmodifiableList(Arrays.asList(new User().setDisplayName(owner))))
-                .setLastModifyingUser(new User().setDisplayName(lastModifyingUser))
-                .setWebViewLink(webViewLink)
-                .setWebContentLink(webContentLink);
+                .setSize(size);
 
         return file;
     }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -31,6 +31,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SHARED_DRIVE_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
@@ -77,6 +79,9 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     private final String folderId = "folderId";
     private final String folderName = "folderName";
 
+    private final String driveId = "drive_id";
+    private final String driveName = "drive_name";
+
     @BeforeEach
     void setUp() throws Exception {
         mockDriverService = mock(Drive.class, Mockito.RETURNS_DEEP_STUBS);
@@ -88,7 +93,15 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                 .execute()
         ).thenReturn(new File()
                 .setName(folderName)
+                .setDriveId(driveId)
         );
+
+        when(mockDriverService.drives()
+                .get(driveId)
+                .setFields("name")
+                .execute()
+                .getName()
+        ).thenReturn(driveName);
 
         testSubject = new ListGoogleDrive() {
             @Override
@@ -200,7 +213,9 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                         "\"drive.parent.folder.id\":\"" + folderId + "\"," +
                         "\"drive.parent.folder.name\":\"" + folderName + "\"," +
                         "\"drive.listed.folder.id\":\"" + folderId + "\"," +
-                        "\"drive.listed.folder.name\":\"" + folderName + "\"" +
+                        "\"drive.listed.folder.name\":\"" + folderName + "\"," +
+                        "\"drive.shared.drive.id\":\"" + driveId + "\"," +
+                        "\"drive.shared.drive.name\":\"" + driveName + "\"" +
                         "}" +
                         "]");
 
@@ -265,6 +280,8 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         inputFlowFileAttributes.put(GoogleDriveAttributes.PARENT_FOLDER_NAME, folderName);
         inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_ID, folderId);
         inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_NAME, folderName);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.SHARED_DRIVE_ID, driveId);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.SHARED_DRIVE_NAME, driveName);
 
 
         HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
@@ -313,6 +330,6 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         return Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList(ID, FILENAME, SIZE, SIZE_AVAILABLE, TIMESTAMP, CREATED_TIME,
                         MODIFIED_TIME, MIME_TYPE, PATH, OWNER, LAST_MODIFYING_USER, WEB_VIEW_LINK, WEB_CONTENT_LINK,
-                PARENT_FOLDER_ID, PARENT_FOLDER_NAME, LISTED_FOLDER_ID, LISTED_FOLDER_NAME)));
+                PARENT_FOLDER_ID, PARENT_FOLDER_NAME, LISTED_FOLDER_ID, LISTED_FOLDER_NAME, SHARED_DRIVE_ID, SHARED_DRIVE_NAME)));
     }
 }

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
@@ -178,6 +180,28 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     }
 
     @Test
+    void testOutputAsAttributesWhereSharedDriveNameIsNotAvailable() throws Exception {
+        when(mockDriverService.drives()
+                .get(driveId)
+                .setFields("name")
+                .execute()
+        ).thenThrow(new HttpResponseException.Builder(404, "Not Found", new HttpHeaders()).build());
+
+        String id = "id_1";
+        String filename = "file_name_1";
+        Long size = null;
+        Long createdTime = 123456L;
+        Long modifiedTime = 123456L + 1L;
+        String mimeType = "mime_type_1";
+        String owner = "user1";
+        String lastModifyingUser = "user2";
+        String webViewLink = "http://web.view";
+        String webContentLink = "http://web.content";
+
+        testOutputAsAttributes(id, filename, size, createdTime, modifiedTime, mimeType, owner, lastModifyingUser, webViewLink, webContentLink, modifiedTime, folderId, folderName, driveId, null);
+    }
+
+    @Test
     void testOutputAsContent() throws Exception {
         String id = "id_1";
         String filename = "file_name_1";
@@ -260,9 +284,25 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     private void testOutputAsAttributes(String id, String filename, Long size, Long createdTime, Long modifiedTime, String mimeType,
                                         String owner, String lastModifyingUser, String webViewLink, String webContentLink,
                                         Long expectedTimestamp) throws IOException {
+        testOutputAsAttributes(id, filename, size, createdTime, modifiedTime, mimeType, owner, lastModifyingUser, webViewLink, webContentLink, expectedTimestamp,
+                folderId, folderName, driveId, driveName);
+    }
+
+    private void testOutputAsAttributes(String id, String filename, Long size, Long createdTime, Long modifiedTime, String mimeType,
+                                        String owner, String lastModifyingUser, String webViewLink, String webContentLink,
+                                        Long expectedTimestamp, String folderId, String folderName, String driveId, String driveName) throws IOException {
         mockFetchedGoogleDriveFileList(id, filename, size, createdTime, modifiedTime, mimeType, owner, lastModifyingUser, webViewLink, webContentLink);
 
-        Map<String, String> inputFlowFileAttributes = new HashMap<>();
+        Map<String, String> inputFlowFileAttributes = new HashMap<>() {
+            @Override
+            public String put(String key, String value) {
+                if (value == null) {
+                    // skip null values as a FlowFile attribute is not added in that case
+                    return null;
+                }
+                return super.put(key, value);
+            }
+        };
         inputFlowFileAttributes.put(GoogleDriveAttributes.ID, id);
         inputFlowFileAttributes.put(GoogleDriveAttributes.FILENAME, filename);
         inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE, valueOf(size != null ? size : 0L));

--- a/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-nar-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -23,9 +23,13 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_C
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LAST_MODIFYING_USER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.LISTED_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.OWNER;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PARENT_FOLDER_NAME;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.PATH;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
@@ -192,7 +196,11 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                         "\"drive.owner\":\"" + owner + "\"," +
                         "\"drive.last.modifying.user\":\"" + lastModifyingUser + "\"," +
                         "\"drive.web.view.link\":\"" + webViewLink + "\"," +
-                        "\"drive.web.content.link\":\"" + webContentLink + "\"" +
+                        "\"drive.web.content.link\":\"" + webContentLink + "\"," +
+                        "\"drive.parent.folder.id\":\"" + folderId + "\"," +
+                        "\"drive.parent.folder.name\":\"" + folderName + "\"," +
+                        "\"drive.listed.folder.id\":\"" + folderId + "\"," +
+                        "\"drive.listed.folder.name\":\"" + folderName + "\"" +
                         "}" +
                         "]");
 
@@ -253,6 +261,10 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         inputFlowFileAttributes.put(GoogleDriveAttributes.LAST_MODIFYING_USER, lastModifyingUser);
         inputFlowFileAttributes.put(GoogleDriveAttributes.WEB_VIEW_LINK, webViewLink);
         inputFlowFileAttributes.put(GoogleDriveAttributes.WEB_CONTENT_LINK, webContentLink);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.PARENT_FOLDER_ID, folderId);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.PARENT_FOLDER_NAME, folderName);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_ID, folderId);
+        inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_NAME, folderName);
 
 
         HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
@@ -300,6 +312,7 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
     public Set<String> getCheckedAttributeNames() {
         return Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList(ID, FILENAME, SIZE, SIZE_AVAILABLE, TIMESTAMP, CREATED_TIME,
-                        MODIFIED_TIME, MIME_TYPE, PATH, OWNER, LAST_MODIFYING_USER, WEB_VIEW_LINK, WEB_CONTENT_LINK)));
+                        MODIFIED_TIME, MIME_TYPE, PATH, OWNER, LAST_MODIFYING_USER, WEB_VIEW_LINK, WEB_CONTENT_LINK,
+                PARENT_FOLDER_ID, PARENT_FOLDER_NAME, LISTED_FOLDER_ID, LISTED_FOLDER_NAME)));
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
