### PR TITLE
OCR-1989 | NIFI-14969 - PutAzureBlobStorage Checksum for validation

### DIFF
--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
@@ -38,8 +38,10 @@ import reactor.netty.http.client.HttpClient;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HexFormat;
 import java.util.Map;
 
 import static org.apache.nifi.processors.azure.storage.utils.ADLSAttributes.ATTR_NAME_FILENAME;
@@ -190,6 +192,21 @@ public final class AzureStorageUtils {
             .allowableValues(AzureStorageConflictResolutionStrategy.class)
             .defaultValue(AzureStorageConflictResolutionStrategy.FAIL_RESOLUTION)
             .description("Specifies whether an existing blob will have its contents replaced upon conflict.")
+            .build();
+
+    public static final PropertyDescriptor CONTENT_MD5 = new PropertyDescriptor.Builder()
+            .name("Content MD5")
+            .displayName("Content MD5")
+            .description("""
+                    The MD5 hash of the content. When this property is set, Azure will validate
+                    the uploaded content against this checksum and reject the upload if it doesn't match. This provides
+                    data integrity verification during transfer. The value can be provided in hexadecimal format (32 characters)
+                    or Base64 format. The MD5 checksum must be computed before invoking this processor;
+                    use the CryptographicHashContent processor with algorithm MD5 to store the result as a FlowFile attribute,
+                    then reference it using Expression Language (e.g., ${content_MD5}).""")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
     public static final String SAS_TOKEN_BASE_DESCRIPTION = "Shared Access Signature token (the leading '?' may be included)";
@@ -351,6 +368,23 @@ public final class AzureStorageUtils {
             return ProxyOptions.Type.valueOf(socksVersion.name());
         } else {
             throw new IllegalArgumentException("Unsupported proxy type: " + proxyConfiguration.getProxyType());
+        }
+    }
+
+    /**
+     * Converts an MD5 checksum string to bytes. Accepts both hexadecimal format (as output by CryptographicHashContent)
+     * and Base64 format.
+     *
+     * @param md5String the MD5 checksum as hex (32 chars) or Base64 (24 chars with padding)
+     * @return the MD5 as a 16-byte array
+     */
+    public static byte[] convertMd5ToBytes(final String md5String) {
+        // MD5 in hex format is 32 characters (128 bits = 16 bytes, 2 hex chars per byte)
+        if (md5String.length() == 32 && md5String.matches("[0-9a-fA-F]+")) {
+            return HexFormat.of().parseHex(md5String);
+        } else {
+            // Assume Base64 format
+            return Base64.getDecoder().decode(md5String);
         }
     }
 


### PR DESCRIPTION
(cherry picked from commit ae2b7348537537702fa50e04f937eb2c0f57cb2d)

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
